### PR TITLE
Add support for shadow jar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ jdk:
 notifications:
   email: false
 
+before_install:
+  - ./scripts/installTileDBJava.sh
+
 install:
   - ./gradlew assemble --info
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ To build and install
     git clone git@github.com:TileDB-Inc/TileDB-Spark.git
     cd TileDB-Spark
     ./gradlew assemble
+    ./gradlew shadowJar
     ./gradlew test
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,16 +64,6 @@ test {
     }
 }
 
-task installTileDBJava(type: Exec) {
-    doFirst {
-        mkdir project.buildDir
-    }
-    workingDir = project.buildDir
-    executable = "../installTileDBJava"
-}
-
-assemble.dependsOn(installTileDBJava)
-
 // metrics.jar
 task metricsJar(type: Jar) {
     baseName = "tiledb-spark-metrics"

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'com.github.sherter.google-java-format' version '0.7.1'
+    id "com.github.johnrengelman.shadow" version "4.0.4"
 }
 
 group 'io.tiledb'
@@ -78,6 +79,14 @@ task getHomeDir {
     doLast {
         println gradle.gradleHomeDir
     }
+}
+
+tasks.jar.configure {
+    classifier = 'default'
+}
+
+tasks.shadowJar.configure {
+    classifier = null
 }
 
 import com.github.sherter.googlejavaformatgradleplugin.GoogleJavaFormat

--- a/scripts/installTileDBJava.sh
+++ b/scripts/installTileDBJava.sh
@@ -5,6 +5,6 @@ fi
 git clone https://github.com/TileDB-Inc/TileDB-Java.git
 pushd TileDB-Java
 git checkout master
-./gradlew assemble --info
-./gradlew publishToMavenLocal --info
+./gradlew -PTILEDB_S3=ON -PTILEDB_VERBOSE=ON assemble --info
+./gradlew -PTILEDB_S3=ON -PTILEDB_VERBOSE=ON publishToMavenLocal --info
 popd


### PR DESCRIPTION
Add support for shadow jar to build fat self container jars. This also removes support for building TileDB-Java and forces the use of the maven package (from maven central or local repo).

Note the maven package still is busted for amazon linux, however once https://github.com/TileDB-Inc/TileDB/pull/1253 is resolved this should be fixed and then this can be merged.