### PR TITLE
Add support for filter pushdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ you need to specify the path to built project jar with `--jars` to upload to the
 
     $ spark-shell --jars build/libs/TileDB-Spark-0.0.1-SNAPSHOT.jar,/path/to/TileDB-Java-0.1.7-SNAPSHOT.jar
 
-To read TileDB data to a dataframe in the TileDB format, specify the `format` and `uri` option
+To read TileDB data to a dataframe in the TileDB format, specify the `format` and `uri` option.
+Optionally include the `read_buffer_size` to set the off heap tiledb buffer sizes per attribute (include coordinates).
  
     scala> val sampleDF = spark.read
                                .format("io.tiledb.spark")
-                               .option("uri", "file:///path/to/tiledb/array") 
+                               .option("uri", "file:///path/to/tiledb/array")
+                               .option("read_buffer_size", 100*1024*1024)
                                .load()
                                
 ### Options
@@ -39,6 +41,7 @@ To read TileDB data to a dataframe in the TileDB format, specify the `format` an
 * `uri` (required): URI to TileDB sparse or dense array
 * `order` (optional): Result layout order `"row-major"`/ `"TILEDB_ROW_MAJOR"`, `"col-major"` / `"TILEDB_COL_MAJOR"`, or `"unordered"`/ `"TILEDB_UNORDERED"` (default `"unordered"`).
 * `tiledb.` (optional): Set a TileDB config option, ex: `option("tiledb.vfs.num_threads", 4)`.  Multiple tiledb config options can be specified.  See the [full list of configuration options](https://docs.tiledb.io/en/latest/tutorials/config.html?highlight=config#summary-of-parameters).
+* `read_buffer_size` (optional): Set the TileDB read buffer size in bytes per attribute/coordinates. Defaults to 10MB
 
 ## Semantics
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compile 'org.apache.spark:spark-sql_2.12:2.4.3'
     compile 'org.apache.spark:spark-core_2.12:2.4.3'
 
-    compile 'io.tiledb:tiledb-java:0.1.7'
+    compile 'io.tiledb:tiledb-java:0.1.8-SNAPSHOT'
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }

--- a/installTileDBJava
+++ b/installTileDBJava
@@ -4,7 +4,7 @@ if [ -d "TileDB-Java" ]; then
 fi
 git clone https://github.com/TileDB-Inc/TileDB-Java.git
 pushd TileDB-Java
-git checkout 0.1.7
+git checkout master
 ./gradlew assemble --info
 ./gradlew publishToMavenLocal --info
 popd

--- a/src/main/java/io/tiledb/spark/TileDBDataReaderPartition.java
+++ b/src/main/java/io/tiledb/spark/TileDBDataReaderPartition.java
@@ -1,25 +1,28 @@
 package io.tiledb.spark;
 
 import java.net.URI;
+import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.sources.v2.reader.InputPartition;
 import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 public class TileDBDataReaderPartition implements InputPartition<ColumnarBatch> {
 
+  private final Filter[] pushedFilters;
   private URI uri;
   private TileDBReadSchema tileDBReadSchema;
   private TileDBDataSourceOptions tiledbOptions;
 
   public TileDBDataReaderPartition(
-      URI uri, TileDBReadSchema schema, TileDBDataSourceOptions options) {
+      URI uri, TileDBReadSchema schema, TileDBDataSourceOptions options, Filter[] pushedFilters) {
     this.uri = uri;
     this.tileDBReadSchema = schema;
     this.tiledbOptions = options;
+    this.pushedFilters = pushedFilters;
   }
 
   @Override
   public InputPartitionReader<ColumnarBatch> createPartitionReader() {
-    return new TileDBDataReaderPartitionScan(uri, tileDBReadSchema, tiledbOptions);
+    return new TileDBDataReaderPartitionScan(uri, tileDBReadSchema, tiledbOptions, pushedFilters);
   }
 }

--- a/src/main/java/io/tiledb/spark/TileDBDataSourceOptions.java
+++ b/src/main/java/io/tiledb/spark/TileDBDataSourceOptions.java
@@ -16,6 +16,9 @@ public class TileDBDataSourceOptions implements Serializable {
   // DataSourceOptions is not serializable so we convert to a Java HashMap
   private HashMap<String, String> optionMap;
 
+  // Query buffer size capacity in bytes (default 10mb)
+  private static final int QUERY_BUFFER_SIZE = 1024 * 1024 * 10;
+
   /**
    * Parses TileDB Spark DataSource and TileDB config options (prefixed with `tiledb.confg = value`)
    *
@@ -32,6 +35,14 @@ public class TileDBDataSourceOptions implements Serializable {
       return Optional.of(new URI(optionMap.get("uri")));
     }
     return Optional.empty();
+  }
+
+  /** @return Optional URI to TileDB array resource * */
+  public long getReadBufferSizes() {
+    if (optionMap.containsKey("read_buffer_size")) {
+      return Long.parseLong(optionMap.get("read_buffer_size"));
+    }
+    return QUERY_BUFFER_SIZE;
   }
 
   /** @return Optional TileDB.Layout description for overriding dataframe sorted order * */

--- a/src/main/java/io/tiledb/spark/TileDBReadSchema.java
+++ b/src/main/java/io/tiledb/spark/TileDBReadSchema.java
@@ -3,6 +3,7 @@ package io.tiledb.spark;
 import io.tiledb.java.api.*;
 import java.io.Serializable;
 import java.net.URI;
+import java.util.HashMap;
 import org.apache.spark.sql.types.*;
 
 public class TileDBReadSchema implements Serializable {
@@ -11,10 +12,13 @@ public class TileDBReadSchema implements Serializable {
   private TileDBDataSourceOptions options;
   private StructType pushDownSparkSchema;
   private StructType tiledbSparkSchema;
+  public HashMap<String, Integer> dimensionIndexes;
 
   public TileDBReadSchema(URI uri, TileDBDataSourceOptions options) {
     this.uri = uri;
     this.options = options;
+    this.dimensionIndexes = new HashMap<>();
+    this.getSparkSchema();
   }
 
   public TileDBReadSchema setPushDownSchema(StructType pushDownSchema) {
@@ -55,6 +59,7 @@ public class TileDBReadSchema implements Serializable {
       for (int i = 0; i < arrayDomain.getNDim(); i++) {
         try (Dimension dim = arrayDomain.getDimension(i)) {
           String dimName = dim.getName();
+          dimensionIndexes.put(dimName, i);
           // schema is immutable so to iteratively add we need to re-assign
           sparkSchema = sparkSchema.add(toStructField(dimName, true, dim.getType(), 1l, false));
         }

--- a/src/test/java/io/tiledb/spark/TileDBDataSourceReadTest.java
+++ b/src/test/java/io/tiledb/spark/TileDBDataSourceReadTest.java
@@ -101,4 +101,140 @@ public class TileDBDataSourceReadTest extends SharedJavaSparkSession {
       }
     }
   }
+
+  @Test
+  public void testQuickStartSparseFilterEqual() {
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.spark")
+            .option("uri", testArrayURIString("quickstart_sparse_array"))
+            .load();
+    dfRead.createOrReplaceTempView("tmp");
+    List<Row> rows = session().sql("SELECT * FROM tmp WHERE rows = 1 and cols = 1").collectAsList();
+    Assert.assertEquals(1, rows.size());
+    // A[1, 1] == 1
+    Row row = rows.get(0);
+    Assert.assertEquals(1, row.getInt(0));
+    Assert.assertEquals(1, row.getInt(1));
+    Assert.assertEquals(1, row.getInt(2));
+    return;
+  }
+
+  @Test
+  public void testQuickStartSparseFilterGreaterThan() {
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.spark")
+            .option("uri", testArrayURIString("quickstart_sparse_array"))
+            .load();
+    dfRead.createOrReplaceTempView("tmp");
+    List<Row> rows = session().sql("SELECT * FROM tmp WHERE rows > 1").collectAsList();
+    Assert.assertEquals(2, rows.size());
+    // A[2, 3] == 3
+    Row row = rows.get(0);
+    Assert.assertEquals(2, row.getInt(0));
+    Assert.assertEquals(3, row.getInt(1));
+    Assert.assertEquals(3, row.getInt(2));
+    // A[2, 4] == 2
+    row = rows.get(1);
+    Assert.assertEquals(2, row.getInt(0));
+    Assert.assertEquals(4, row.getInt(1));
+    Assert.assertEquals(2, row.getInt(2));
+    return;
+  }
+
+  @Test
+  public void testQuickStartSparseFilterGreaterThanEqual() {
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.spark")
+            .option("uri", testArrayURIString("quickstart_sparse_array"))
+            .load();
+    dfRead.createOrReplaceTempView("tmp");
+    List<Row> rows = session().sql("SELECT * FROM tmp WHERE rows >= 2").collectAsList();
+    Assert.assertEquals(2, rows.size());
+    // A[2, 3] == 3
+    Row row = rows.get(0);
+    Assert.assertEquals(2, row.getInt(0));
+    Assert.assertEquals(3, row.getInt(1));
+    Assert.assertEquals(3, row.getInt(2));
+    // A[2, 4] == 2
+    row = rows.get(1);
+    Assert.assertEquals(2, row.getInt(0));
+    Assert.assertEquals(4, row.getInt(1));
+    Assert.assertEquals(2, row.getInt(2));
+    return;
+  }
+
+  @Test
+  public void testQuickStartSparseFilterLessThan() {
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.spark")
+            .option("uri", testArrayURIString("quickstart_sparse_array"))
+            .load();
+    dfRead.createOrReplaceTempView("tmp");
+    List<Row> rows = session().sql("SELECT * FROM tmp WHERE rows < 2").collectAsList();
+    Assert.assertEquals(1, rows.size());
+    // A[1, 1] == 1
+    Row row = rows.get(0);
+    Assert.assertEquals(1, row.getInt(0));
+    Assert.assertEquals(1, row.getInt(1));
+    Assert.assertEquals(1, row.getInt(2));
+    return;
+  }
+
+  @Test
+  public void testQuickStartSparseFilterLessThanEqual() {
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.spark")
+            .option("uri", testArrayURIString("quickstart_sparse_array"))
+            .load();
+    dfRead.createOrReplaceTempView("tmp");
+    List<Row> rows =
+        session().sql("SELECT * FROM tmp WHERE rows <= 2 AND cols <= 3").collectAsList();
+    Assert.assertEquals(2, rows.size());
+    // A[1, 1] == 1
+    Row row = rows.get(0);
+    Assert.assertEquals(1, row.getInt(0));
+    Assert.assertEquals(1, row.getInt(1));
+    Assert.assertEquals(1, row.getInt(2));
+    // A[2, 3] == 3
+    row = rows.get(1);
+    Assert.assertEquals(2, row.getInt(0));
+    Assert.assertEquals(3, row.getInt(1));
+    Assert.assertEquals(3, row.getInt(2));
+    return;
+  }
+
+  @Test
+  public void testQuickStartSparseFilterIn() {
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.spark")
+            .option("uri", testArrayURIString("quickstart_sparse_array"))
+            .load();
+    dfRead.createOrReplaceTempView("tmp");
+    List<Row> rows =
+        session().sql("SELECT * FROM tmp WHERE rows IN (1, 2) AND cols IN (1,3)").collectAsList();
+    Assert.assertEquals(2, rows.size());
+    // A[1, 1] == 1
+    Row row = rows.get(0);
+    Assert.assertEquals(1, row.getInt(0));
+    Assert.assertEquals(1, row.getInt(1));
+    Assert.assertEquals(1, row.getInt(2));
+    // A[2, 3] == 3
+    row = rows.get(1);
+    Assert.assertEquals(2, row.getInt(0));
+    Assert.assertEquals(3, row.getInt(1));
+    Assert.assertEquals(3, row.getInt(2));
+    return;
+  }
 }

--- a/src/test/java/io/tiledb/spark/TileDBDataSourceReadTestBufferSizes.java
+++ b/src/test/java/io/tiledb/spark/TileDBDataSourceReadTestBufferSizes.java
@@ -1,0 +1,51 @@
+package io.tiledb.spark;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TileDBDataSourceReadTestBufferSizes extends SharedJavaSparkSession {
+
+  private String testArrayURIString(String arrayName) {
+    Path arraysPath = Paths.get("src", "test", "resources", "data", arrayName);
+    return "file://".concat(arraysPath.toAbsolutePath().toString());
+  }
+
+  /**
+   * This test uses an 8 byte buffer which is enough for 1 cell (2 coordinates at 4 byte a piece) It
+   * validates that incomplete queries are working
+   */
+  @Test
+  public void testQuickStartSparseWith8ByteBuffer() {
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.spark")
+            .option("uri", testArrayURIString("quickstart_sparse_array"))
+            .option("read_buffer_size", 8)
+            .load();
+    dfRead.createOrReplaceTempView("tmp");
+    List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
+    Assert.assertEquals(3, rows.size());
+    // A[1, 1] == 1
+    Row row = rows.get(0);
+    Assert.assertEquals(1, row.getInt(0));
+    Assert.assertEquals(1, row.getInt(1));
+    Assert.assertEquals(1, row.getInt(2));
+    // A[2, 3] == 3
+    row = rows.get(1);
+    Assert.assertEquals(2, row.getInt(0));
+    Assert.assertEquals(3, row.getInt(1));
+    Assert.assertEquals(3, row.getInt(2));
+    // A[2, 4] == 2
+    row = rows.get(2);
+    Assert.assertEquals(2, row.getInt(0));
+    Assert.assertEquals(4, row.getInt(1));
+    Assert.assertEquals(2, row.getInt(2));
+    return;
+  }
+}


### PR DESCRIPTION
Add support for filter pushdown. This also includes support for flexible buffer sizes (but not realloc yet, separate PR inbound). The max buffer elements support had to be removed for use of the multi-range.