### PR TITLE
Fix floating-point partitioning

### DIFF
--- a/src/main/java/io/tiledb/spark/Range.java
+++ b/src/main/java/io/tiledb/spark/Range.java
@@ -601,7 +601,7 @@ public class Range implements java.io.Serializable, Comparable<Range> {
    * @return The list of ranges, one per partition
    * @throws TileDBError A TileDBError exception
    */
-  public List<Range> splitRangeToPartitions(int partitions, long partitionWidth)
+  public List<Range> splitRangeToPartitions(int partitions, double partitionWidth)
       throws TileDBError {
     List<Range> ranges = new ArrayList<>();
     // Number of buckets is 1 more thank number of splits (i.e. split 1 time into two buckets)
@@ -610,7 +610,18 @@ public class Range implements java.io.Serializable, Comparable<Range> {
     Number max = (Number) range.getSecond();
     Number currentMin;
     Number currentMax;
-    Number pWidth = (Number) util.castLong(partitionWidth, dataClassType);
+    Number pWidth;
+
+    if (dataClassType == Float.class || dataClassType == Double.class) {
+      pWidth = partitionWidth;
+    } else {
+      if (partitionWidth < 1) {
+        long actualWidth = this.width().longValue();
+        partitions = (int) actualWidth;
+        partitionWidth = 1;
+      }
+      pWidth = (Number) util.castLong((long) partitionWidth, dataClassType);
+    }
 
     // If the min is the max this range is not splittable
     if (!this.splittable()) {

--- a/src/main/java/io/tiledb/spark/SubArrayRanges.java
+++ b/src/main/java/io/tiledb/spark/SubArrayRanges.java
@@ -275,14 +275,7 @@ public class SubArrayRanges implements Comparable<SubArrayRanges> {
         long actualWidth = ranges.get(0).width().longValue();
         double exactEffectiveWidth = actualWidth * 1.0 / partitions;
 
-        long partitionWidth = (long) exactEffectiveWidth;
-
-        if (exactEffectiveWidth < 1) {
-          partitions = (int) actualWidth;
-          partitionWidth = 1;
-        }
-
-        newRanges = ranges.get(0).splitRangeToPartitions(partitions, partitionWidth);
+        newRanges = ranges.get(0).splitRangeToPartitions(partitions, exactEffectiveWidth);
       }
 
       for (Range newRange : newRanges) {

--- a/src/test/java/io/tiledb/spark/SparkPartitioningTest.java
+++ b/src/test/java/io/tiledb/spark/SparkPartitioningTest.java
@@ -204,12 +204,12 @@ public class SparkPartitioningTest extends SharedJavaSparkSession implements Ser
 
   @Test
   public void testPartitioningDouble2() {
-    testWriteRead(createDoubleDataset(session()), 10, 9, "a1");
+    testWriteRead(createDoubleDataset(session()), 100, 100, "a1");
   }
 
   @Test
   public void testPartitioningDouble3() {
-    testWriteRead(createDoubleDataset(session()), 2, 2, "a1");
+    testWriteRead(createDoubleDataset(session()), 429, 429, "a1");
   }
 
   public Dataset<Row> createStringDataset(SparkSession ss) {


### PR DESCRIPTION
Fixed floating-point partitioning issue in order to create equi-width partitions for dimensions of `float`/`double` type.