### PR TITLE
Increased maxHeapSize to 2048m

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 }
 
 test {
+    maxHeapSize = "2048m"
     systemProperty "java.library.path", new File(buildDir, "TileDB-Java/build/tiledb_jni")
     testLogging {
         showStandardStreams = true


### PR DESCRIPTION
Increased the maxHeapSize to `2048` MB to resolve the Java Heap Space OOM issues in CI