### PR TITLE
Dstara/sc 698/support filepath instead of uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,18 @@ Optionally include the `read_buffer_size` to set the off heap tiledb buffer size
  
     scala> val sampleDF = spark.read
                                .format("io.tiledb.spark")
-                               .option("uri", "file:///path/to/tiledb/array")
                                .option("read_buffer_size", 100*1024*1024)
-                               .load()
+                               .load("file:///path/to/tiledb/array")
 
 To write to TileDB from an existing dataframe, you need to specify a URI and the column(s) which map to sparse array dimensions.  For now only sparse array writes are supported.
 
     scala > val sampleDF.write
                         .format("io.tiledb.spark")
-                        .option("uri", "file:///path/to/tiledb/array_new")                          
                         .option("schema.dim.0.name", "rows")
                         .option("schema.dim.1.name", "cols")
                         .option("write_buffer_size", 100*1024*1024)
                         .mode(SaveMode.ErrorIfExists)
-                        .save();
+                        .save("file:///path/to/tiledb/array_new");
 
 ## Metrics
 
@@ -76,7 +74,7 @@ to `$SPARK_HOME/jars/`.
 ## Options
 
 ### Read/Write options
-* `uri` (required): URI to TileDB sparse or dense array
+* `uri` (legacy): URI to TileDB sparse or dense array. URI should be a parameter of load()/save() instead.
 * `tiledb.` (optional): Set a TileDB config option, ex: `option("tiledb.vfs.num_threads", 4)`.  Multiple tiledb config options can be
    specified.  See the
   [full list of configuration options](https://docs.tiledb.io/en/latest/tutorials/config.html?highlight=config#summary-of-parameters).

--- a/src/main/java/io/tiledb/spark/TileDBBatch.java
+++ b/src/main/java/io/tiledb/spark/TileDBBatch.java
@@ -60,7 +60,7 @@ public class TileDBBatch implements Batch {
     try {
       Context ctx = new Context(tileDBDataSourceOptions.getTileDBConfigMap(true));
       // Fetch the array and load its metadata
-      Array array = new Array(ctx, util.tryGetArrayURI(tileDBDataSourceOptions).toString());
+      Array array = new Array(ctx, util.tryGetArrayURI(tileDBDataSourceOptions));
       HashMap<String, Pair> nonEmptyDomain = array.nonEmptyDomain();
       Domain domain = array.getSchema().getDomain();
 

--- a/src/main/java/io/tiledb/spark/TileDBBatchWrite.java
+++ b/src/main/java/io/tiledb/spark/TileDBBatchWrite.java
@@ -12,7 +12,6 @@ import io.tiledb.java.api.Layout;
 import io.tiledb.java.api.Pair;
 import io.tiledb.java.api.TileDBError;
 import io.tiledb.java.api.TileDBObject;
-import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +29,7 @@ public class TileDBBatchWrite implements BatchWrite {
   private final Map<String, String> properties;
   private final TileDBDataSourceOptions tileDBDataSourceOptions;
   public final SaveMode saveMode;
-  private final URI uri;
+  private final String uri;
   private final LogicalWriteInfo logicalWriteInfo;
   private final StructType sparkSchema;
 
@@ -97,7 +96,7 @@ public class TileDBBatchWrite implements BatchWrite {
   }
 
   private static void writeArraySchema(
-      Context ctx, URI uri, StructType sparkSchema, TileDBDataSourceOptions options)
+      Context ctx, String uri, StructType sparkSchema, TileDBDataSourceOptions options)
       throws TileDBError {
     ArrayType type = ArrayType.TILEDB_SPARSE;
     try (ArraySchema arraySchema = new ArraySchema(ctx, type);
@@ -160,7 +159,7 @@ public class TileDBBatchWrite implements BatchWrite {
         arraySchema.setAllowDups(1);
 
       arraySchema.check();
-      Array.create(uri.toString(), arraySchema);
+      Array.create(uri, arraySchema);
     }
   }
 }

--- a/src/main/java/io/tiledb/spark/TileDBDataInputPartition.java
+++ b/src/main/java/io/tiledb/spark/TileDBDataInputPartition.java
@@ -1,6 +1,5 @@
 package io.tiledb.spark;
 
-import java.net.URI;
 import java.util.List;
 import org.apache.spark.sql.connector.read.InputPartition;
 
@@ -8,12 +7,12 @@ public class TileDBDataInputPartition implements InputPartition {
 
   private final List<List<Range>> dimensionRanges;
   private final List<List<Range>> attributeRanges;
-  private URI uri;
+  private String uri;
   private TileDBReadSchema tileDBReadSchema;
   private TileDBDataSourceOptions tiledbOptions;
 
   public TileDBDataInputPartition(
-      URI uri,
+      String uri,
       TileDBReadSchema schema,
       TileDBDataSourceOptions options,
       List<List<Range>> dimensionRanges,
@@ -33,7 +32,7 @@ public class TileDBDataInputPartition implements InputPartition {
     return attributeRanges;
   }
 
-  public URI getUri() {
+  public String getUri() {
     return uri;
   }
 

--- a/src/main/java/io/tiledb/spark/TileDBDataSource.java
+++ b/src/main/java/io/tiledb/spark/TileDBDataSource.java
@@ -14,6 +14,7 @@ public class TileDBDataSource implements TableProvider {
 
   @Override
   public StructType inferSchema(CaseInsensitiveStringMap options) {
+
     TileDBDataSourceOptions tiledbOptions =
         new TileDBDataSourceOptions(new DataSourceOptions(options));
 

--- a/src/main/java/io/tiledb/spark/TileDBDataSourceOptions.java
+++ b/src/main/java/io/tiledb/spark/TileDBDataSourceOptions.java
@@ -3,7 +3,6 @@ package io.tiledb.spark;
 import io.tiledb.java.api.Layout;
 import io.tiledb.java.api.Pair;
 import java.io.Serializable;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -33,9 +32,15 @@ public class TileDBDataSourceOptions implements Serializable {
    * @return Optional URI to TileDB array resource
    * @throws URISyntaxException A URISyntaxException exception
    */
-  public Optional<URI> getArrayURI() throws URISyntaxException {
+  public Optional<String> getArrayURI() throws URISyntaxException {
+    if (optionMap.containsKey("path")) {
+      return Optional.of(optionMap.get("path"));
+    }
+    // the following 'if' should enable passing the uri as an option as it was implemented
+    // originally. The 'spark' way requires the uri to be inside the 'load()' method call.
+    // this is left here for backwards compatibility.
     if (optionMap.containsKey("uri")) {
-      return Optional.of(new URI(optionMap.get("uri")));
+      return Optional.of(optionMap.get("uri"));
     }
     return Optional.empty();
   }

--- a/src/main/java/io/tiledb/spark/TileDBDataWriter.java
+++ b/src/main/java/io/tiledb/spark/TileDBDataWriter.java
@@ -11,7 +11,6 @@ import static org.apache.spark.metrics.TileDBMetricsSource.queryWriteTimerName;
 
 import io.tiledb.java.api.*;
 import java.io.IOException;
-import java.net.URI;
 import java.sql.Timestamp;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -34,7 +33,7 @@ public class TileDBDataWriter implements DataWriter<InternalRow> {
 
   private final TileDBWriteMetricsUpdater metricsUpdater;
   private final TaskContext task;
-  private URI uri;
+  private String uri;
   private StructType sparkSchema;
 
   private Context ctx;
@@ -63,7 +62,7 @@ public class TileDBDataWriter implements DataWriter<InternalRow> {
   private static final OffsetDateTime zeroDateTime =
       new Timestamp(0).toLocalDateTime().atOffset(ZoneOffset.UTC);
 
-  public TileDBDataWriter(URI uri, StructType schema, TileDBDataSourceOptions options) {
+  public TileDBDataWriter(String uri, StructType schema, TileDBDataSourceOptions options) {
     this.uri = uri;
     this.sparkSchema = schema;
     // set write options

--- a/src/main/java/io/tiledb/spark/TileDBDataWriterFactory.java
+++ b/src/main/java/io/tiledb/spark/TileDBDataWriterFactory.java
@@ -1,6 +1,5 @@
 package io.tiledb.spark;
 
-import java.net.URI;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.DataWriterFactory;
@@ -8,11 +7,12 @@ import org.apache.spark.sql.types.StructType;
 
 public class TileDBDataWriterFactory implements DataWriterFactory {
 
-  private URI uri;
+  private String uri;
   private StructType sparkSchema;
   private TileDBDataSourceOptions options;
 
-  public TileDBDataWriterFactory(URI uri, StructType sparkSchema, TileDBDataSourceOptions options) {
+  public TileDBDataWriterFactory(
+      String uri, StructType sparkSchema, TileDBDataSourceOptions options) {
     this.uri = uri;
     this.sparkSchema = sparkSchema;
     this.options = options;

--- a/src/main/java/io/tiledb/spark/TileDBPartitionReader.java
+++ b/src/main/java/io/tiledb/spark/TileDBPartitionReader.java
@@ -16,7 +16,6 @@ import static org.apache.spark.metrics.TileDBMetricsSource.tileDBReadQuerySubmit
 
 import io.tiledb.java.api.*;
 import java.math.BigInteger;
-import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.sql.Timestamp;
@@ -75,7 +74,7 @@ public class TileDBPartitionReader implements PartitionReader<ColumnarBatch> {
   private long read_query_buffer_size;
 
   // array resource URI (dense or sparse)
-  private URI arrayURI;
+  private String arrayURI;
 
   // spark options
   private TileDBDataSourceOptions options;
@@ -262,7 +261,7 @@ public class TileDBPartitionReader implements PartitionReader<ColumnarBatch> {
   }
 
   public TileDBPartitionReader(
-      URI uri,
+      String uri,
       TileDBReadSchema schema,
       TileDBDataSourceOptions options,
       List<List<Range>> dimensionRanges,
@@ -359,7 +358,7 @@ public class TileDBPartitionReader implements PartitionReader<ColumnarBatch> {
    * @throws TileDBError
    */
   private Array openArray(
-      Context ctx, URI arrayURI, QueryType queryType, TileDBDataSourceOptions options)
+      Context ctx, String arrayURI, QueryType queryType, TileDBDataSourceOptions options)
       throws TileDBError {
     Optional<Long> timestampStart = options.getTimestampStart();
     Optional<Long> timestampEnd = options.getTimestampEnd();
@@ -367,16 +366,16 @@ public class TileDBPartitionReader implements PartitionReader<ColumnarBatch> {
     if (timestampStart.isPresent() && timestampEnd.isPresent()) {
       return new Array(
           ctx,
-          arrayURI.toString(),
+          arrayURI,
           queryType,
           BigInteger.valueOf(timestampStart.get()),
           BigInteger.valueOf(timestampEnd.get()));
     }
     if (timestampEnd.isPresent()) {
-      return new Array(ctx, arrayURI.toString(), queryType, BigInteger.valueOf(timestampEnd.get()));
+      return new Array(ctx, arrayURI, queryType, BigInteger.valueOf(timestampEnd.get()));
     }
 
-    return new Array(ctx, arrayURI.toString(), queryType);
+    return new Array(ctx, arrayURI, queryType);
   }
 
   @Override

--- a/src/main/java/io/tiledb/spark/TileDBPartitionReaderLegacy.java
+++ b/src/main/java/io/tiledb/spark/TileDBPartitionReaderLegacy.java
@@ -20,7 +20,6 @@ import static org.apache.spark.metrics.TileDBMetricsSource.queryReadTimerTaskNam
 import static org.apache.spark.metrics.TileDBMetricsSource.tileDBReadQuerySubmitTimerName;
 
 import io.tiledb.java.api.*;
-import java.net.URI;
 import java.sql.Timestamp;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -60,7 +59,7 @@ public class TileDBPartitionReaderLegacy implements PartitionReader<ColumnarBatc
   private long read_query_buffer_size;
 
   // array resource URI (dense or sparse)
-  private URI arrayURI;
+  private String arrayURI;
 
   // spark options
   private TileDBDataSourceOptions options;
@@ -98,7 +97,7 @@ public class TileDBPartitionReaderLegacy implements PartitionReader<ColumnarBatc
   private ArrayList<Pair<NativeArray, NativeArray>> queryBuffers;
 
   public TileDBPartitionReaderLegacy(
-      URI uri,
+      String uri,
       TileDBReadSchema schema,
       TileDBDataSourceOptions options,
       List<List<Range>> dimensionRanges,
@@ -135,7 +134,7 @@ public class TileDBPartitionReaderLegacy implements PartitionReader<ColumnarBatc
     try {
       // Init TileDB resources
       ctx = new Context(options.getTileDBConfigMap(false));
-      array = new Array(ctx, arrayURI.toString(), QueryType.TILEDB_READ);
+      array = new Array(ctx, arrayURI, QueryType.TILEDB_READ);
       arraySchema = array.getSchema();
       domain = arraySchema.getDomain();
 

--- a/src/main/java/io/tiledb/spark/TileDBReadSchema.java
+++ b/src/main/java/io/tiledb/spark/TileDBReadSchema.java
@@ -2,14 +2,13 @@ package io.tiledb.spark;
 
 import io.tiledb.java.api.*;
 import java.io.Serializable;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.Optional;
 import org.apache.spark.sql.types.*;
 
 public class TileDBReadSchema implements Serializable {
 
-  private URI uri;
+  private String uri;
   private TileDBDataSourceOptions options;
   private StructType pushDownSparkSchema;
   private StructType tiledbSparkSchema;
@@ -19,7 +18,7 @@ public class TileDBReadSchema implements Serializable {
   public HashMap<Integer, String> attributeName;
   public HashMap<Integer, Datatype> columnTypes;
 
-  public TileDBReadSchema(URI uri, TileDBDataSourceOptions options) {
+  public TileDBReadSchema(String uri, TileDBDataSourceOptions options) {
     this.uri = uri;
     this.options = options;
     this.dimensionIndex = new HashMap<>();

--- a/src/main/java/io/tiledb/spark/TileDBScan.java
+++ b/src/main/java/io/tiledb/spark/TileDBScan.java
@@ -2,7 +2,6 @@ package io.tiledb.spark;
 
 import static org.apache.spark.metrics.TileDBMetricsSource.dataSourceReadSchemaTimerName;
 
-import java.net.URI;
 import org.apache.log4j.Logger;
 import org.apache.spark.TaskContext;
 import org.apache.spark.metrics.TileDBReadMetricsUpdater;
@@ -18,7 +17,7 @@ public class TileDBScan implements Scan {
   private final TileDBReadSchema tileDBReadSchema;
   private final TileDBDataSourceOptions options;
   private final Filter[] pushedFilters;
-  private final URI uri;
+  private final String uri;
 
   private final TileDBReadMetricsUpdater metricsUpdater;
   static Logger log = Logger.getLogger(TileDBScan.class.getName());

--- a/src/main/java/io/tiledb/spark/TileDBScanBuilder.java
+++ b/src/main/java/io/tiledb/spark/TileDBScanBuilder.java
@@ -3,7 +3,6 @@ package io.tiledb.spark;
 import static org.apache.spark.metrics.TileDBMetricsSource.dataSourcePruneColumnsTimerName;
 import static org.apache.spark.metrics.TileDBMetricsSource.dataSourcePushFiltersTimerName;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Map;
@@ -30,7 +29,7 @@ public class TileDBScanBuilder
   private final TileDBReadMetricsUpdater metricsUpdater;
   private final TileDBReadSchema tileDBReadSchema;
   private Filter[] pushedFilters;
-  private URI uri;
+  private String uri;
 
   static Logger log = Logger.getLogger(TileDBScanBuilder.class.getName());
 

--- a/src/main/java/io/tiledb/spark/util.java
+++ b/src/main/java/io/tiledb/spark/util.java
@@ -3,7 +3,6 @@ package io.tiledb.spark;
 import io.tiledb.java.api.Datatype;
 import io.tiledb.java.api.TileDBError;
 import io.tiledb.java.api.Util;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,15 +56,15 @@ public class util {
     }
   }
 
-  public static URI tryGetArrayURI(TileDBDataSourceOptions tiledbOptions) {
-    Optional<URI> arrayURI;
+  public static String tryGetArrayURI(TileDBDataSourceOptions tiledbOptions) {
+    Optional<String> arrayURI;
     try {
       arrayURI = tiledbOptions.getArrayURI();
     } catch (URISyntaxException ex) {
       throw new RuntimeException("Error parsing array URI option: " + ex.getMessage());
     }
     if (!arrayURI.isPresent()) {
-      throw new RuntimeException("TileDB URI option required");
+      throw new RuntimeException("TileDB URI required");
     }
     return arrayURI.get();
   }

--- a/src/test/java/io/tiledb/spark/JSONReadTest.java
+++ b/src/test/java/io/tiledb/spark/JSONReadTest.java
@@ -60,12 +60,11 @@ public class JSONReadTest extends SharedJavaSparkSession {
 
     ds.write()
         .format("io.tiledb.spark")
-        .option("uri", URI)
         .option("schema.dim.0.name", "study_id")
         .mode("overwrite")
-        .save();
+        .save(URI);
 
-    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").option("uri", URI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(URI);
     // use default buffer read size
 
     // Spark dataframes are lazy which means that since we do not check the data of the dataframes

--- a/src/test/java/io/tiledb/spark/NullableAttributesTest.java
+++ b/src/test/java/io/tiledb/spark/NullableAttributesTest.java
@@ -131,7 +131,7 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
   public void denseArrayReadTest() throws Exception {
     denseArrayCreate();
     denseArrayWrite();
-    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").option("uri", denseURI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(denseURI);
 
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
@@ -221,8 +221,7 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
   public void denseArrayVarAttReadTest() throws Exception {
     denseArrayVarAttCreate();
     denseArrayVarAttWrite();
-    Dataset<Row> dfRead =
-        session().read().format("io.tiledb.spark").option("uri", variableAttURI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(variableAttURI);
     // dfRead.show();
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
@@ -339,8 +338,7 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
   public void sparseArrayReadTest() throws Exception {
     sparseArrayCreate();
     sparseArrayWrite();
-    Dataset<Row> dfRead =
-        session().read().format("io.tiledb.spark").option("uri", sparseURI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(sparseURI);
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
     Assert.assertEquals(5, rows.size());
@@ -432,7 +430,6 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
     dfReadFirst
         .write()
         .format("io.tiledb.spark")
-        .option("uri", writeArrayURI)
         .option("schema.dim.0.name", "d1")
         .option("schema.dim.0.min", 1)
         .option("schema.dim.0.max", 8)
@@ -442,10 +439,9 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
         .option("schema.tile_order", "row-major")
         .option("schema.capacity", 3)
         .mode("overwrite")
-        .save();
+        .save(writeArrayURI);
 
-    Dataset<Row> dfRead =
-        session().read().format("io.tiledb.spark").option("uri", writeArrayURI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(writeArrayURI);
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
     Assert.assertEquals(5, rows.size());
@@ -483,7 +479,6 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
     dfReadFirst
         .write()
         .format("io.tiledb.spark")
-        .option("uri", writeArrayURI)
         .option("schema.dim.0.name", "d1")
         .option("schema.dim.0.min", 1)
         .option("schema.dim.0.max", 8)
@@ -493,7 +488,7 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
         .option("schema.tile_order", "row-major")
         .option("schema.capacity", 3)
         .mode("overwrite")
-        .save();
+        .save(writeArrayURI);
 
     Dataset<Row> dfRead =
         session().read().format("io.tiledb.spark").option("uri", writeArrayURI).load();
@@ -538,7 +533,7 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
     denseArrayCreate();
     denseArrayWrite();
 
-    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").option("uri", denseURI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(denseURI);
 
     dfRead.show();
 
@@ -578,8 +573,7 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
         .mode("overwrite")
         .save();
 
-    Dataset<Row> dfReadSecond =
-        session().read().format("io.tiledb.spark").option("uri", tempWrite).load();
+    Dataset<Row> dfReadSecond = session().read().format("io.tiledb.spark").load(tempWrite);
 
     Assert.assertTrue(assertDataFrameEquals(expected, dfReadSecond));
 

--- a/src/test/java/io/tiledb/spark/SparkDatetypesTest.java
+++ b/src/test/java/io/tiledb/spark/SparkDatetypesTest.java
@@ -198,7 +198,7 @@ public class SparkDatetypesTest extends SharedJavaSparkSession {
    */
   @Test
   public void testDateTypesDenseRead() {
-    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").option("uri", denseURI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(denseURI);
     dfRead.show();
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
@@ -315,7 +315,6 @@ public class SparkDatetypesTest extends SharedJavaSparkSession {
     dfReadFirst
         .write()
         .format("io.tiledb.spark")
-        .option("uri", tempWrite)
         .option("schema.dim.0.name", "rows")
         .option("schema.dim.0.min", 1)
         .option("schema.dim.0.max", 4)
@@ -324,10 +323,9 @@ public class SparkDatetypesTest extends SharedJavaSparkSession {
         .option("schema.cell_order", "row-major")
         .option("schema.tile_order", "row-major")
         .mode("overwrite")
-        .save();
+        .save(tempWrite);
 
-    Dataset<Row> dfRead =
-        session().read().format("io.tiledb.spark").option("uri", tempWrite).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(tempWrite);
     dfReadFirst.show();
     dfRead.show();
     Dataset<Row> dfReadConverted =
@@ -352,15 +350,13 @@ public class SparkDatetypesTest extends SharedJavaSparkSession {
    */
   @Test
   public void testDateTypesDenseReadWrite() throws TileDBError {
-    Dataset<Row> dfReadFirst =
-        session().read().format("io.tiledb.spark").option("uri", denseURI).load();
+    Dataset<Row> dfReadFirst = session().read().format("io.tiledb.spark").load(denseURI);
 
     dfReadFirst.cache();
 
     dfReadFirst
         .write()
         .format("io.tiledb.spark")
-        .option("uri", writeURI)
         .option("schema.dim.0.name", "rows")
         .option("schema.dim.0.min", 1)
         .option("schema.dim.0.max", 2)
@@ -368,9 +364,9 @@ public class SparkDatetypesTest extends SharedJavaSparkSession {
         .option("schema.cell_order", "row-major")
         .option("schema.tile_order", "row-major")
         .mode("overwrite")
-        .save();
+        .save(writeURI);
 
-    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").option("uri", writeURI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(writeURI);
 
     dfRead.show();
     Assert.assertTrue(assertDataFrameEquals(dfReadFirst, dfRead));
@@ -480,7 +476,6 @@ public class SparkDatetypesTest extends SharedJavaSparkSession {
     dfToAppend
         .write()
         .format("io.tiledb.spark")
-        .option("uri", sparseURI)
         .option("schema.dim.0.name", "rows")
         .option("schema.dim.0.min", 1)
         .option("schema.dim.0.max", 8)
@@ -488,10 +483,9 @@ public class SparkDatetypesTest extends SharedJavaSparkSession {
         .option("schema.cell_order", "row-major")
         .option("schema.tile_order", "row-major")
         .mode("append")
-        .save();
+        .save(sparseURI);
 
-    Dataset<Row> dfRead =
-        session().read().format("io.tiledb.spark").option("uri", sparseURI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(sparseURI);
     dfRead.show();
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rowsOfnew = session().sql("SELECT * FROM tmp").collectAsList();

--- a/src/test/java/io/tiledb/spark/SparkPartitioningTest.java
+++ b/src/test/java/io/tiledb/spark/SparkPartitioningTest.java
@@ -22,18 +22,16 @@ public class SparkPartitioningTest extends SharedJavaSparkSession implements Ser
     persistedDF
         .write()
         .format("io.tiledb.spark")
-        .option("uri", arrayURI)
         .option("schema.dim.0.name", dimensionName)
         .mode("overwrite")
-        .save();
+        .save(arrayURI);
 
     Dataset<Row> inputDF =
         session()
             .read()
             .format("io.tiledb.spark")
             .option("partition_count", partitions)
-            .option("uri", arrayURI)
-            .load();
+            .load(arrayURI);
 
     inputDF.show();
 
@@ -46,19 +44,17 @@ public class SparkPartitioningTest extends SharedJavaSparkSession implements Ser
     persistedDF
         .write()
         .format("io.tiledb.spark")
-        .option("uri", arrayURI)
         .option("schema.dim.0.name", "a1")
         .option("schema.dim.1.name", "a2")
         .mode("overwrite")
-        .save();
+        .save(arrayURI);
 
     Dataset<Row> inputDF =
         session()
             .read()
             .format("io.tiledb.spark")
             .option("partition_count", partitions)
-            .option("uri", arrayURI)
-            .load();
+            .load(arrayURI);
 
     if (where.isPresent()) inputDF = inputDF.where(where.get());
 

--- a/src/test/java/io/tiledb/spark/TestReadWriteNDDense.java
+++ b/src/test/java/io/tiledb/spark/TestReadWriteNDDense.java
@@ -47,13 +47,11 @@ public class TestReadWriteNDDense extends SharedJavaSparkSession {
         session()
             .read()
             .format("io.tiledb.spark")
-            .option("uri", testArrayURIString("writing_dense_global_array"))
-            .load();
+            .load(testArrayURIString("writing_dense_global_array"));
     // Array will be written as Sparse. TileDB-Spark does not support dense writes.
     dfReadFirst
         .write()
         .format("io.tiledb.spark")
-        .option("uri", arrayURI)
         .option("schema.dim.0.name", "rows")
         .option("schema.dim.0.min", 1)
         .option("schema.dim.0.max", 4)
@@ -67,9 +65,9 @@ public class TestReadWriteNDDense extends SharedJavaSparkSession {
         .option("schema.tile_order", "row-major")
         .option("schema.capacity", 3)
         .mode("overwrite")
-        .save();
+        .save(arrayURI);
 
-    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").option("uri", arrayURI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(arrayURI);
 
     // check values
     dfRead.createOrReplaceTempView("tmp");

--- a/src/test/java/io/tiledb/spark/TestReadWriteNDSparse.java
+++ b/src/test/java/io/tiledb/spark/TestReadWriteNDSparse.java
@@ -51,13 +51,11 @@ public class TestReadWriteNDSparse extends SharedJavaSparkSession {
         session()
             .read()
             .format("io.tiledb.spark")
-            .option("uri", testArrayURIString("quickstart_sparse_array"))
-            .load();
+            .load(testArrayURIString("quickstart_sparse_array"));
     dfReadFirst.show();
     dfReadFirst
         .write()
         .format("io.tiledb.spark")
-        .option("uri", writeArrayURI)
         .option("schema.dim.0.name", "rows")
         .option("schema.dim.0.min", 1)
         .option("schema.dim.0.max", 2)
@@ -71,10 +69,9 @@ public class TestReadWriteNDSparse extends SharedJavaSparkSession {
         .option("schema.tile_order", "row-major")
         .option("schema.capacity", 3)
         .mode("overwrite")
-        .save();
+        .save(writeArrayURI);
 
-    Dataset<Row> dfRead =
-        session().read().format("io.tiledb.spark").option("uri", writeArrayURI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(writeArrayURI);
 
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
@@ -121,7 +118,6 @@ public class TestReadWriteNDSparse extends SharedJavaSparkSession {
     DataFrameWriter<Row> writer =
         df.write()
             .format("io.tiledb.spark")
-            .option("uri", arrayURI)
             .option("schema.dim.0.name", "d1")
             .option("schema.dim.0.extent", 2)
             .option("schema.cell_order", "row-major")
@@ -130,13 +126,13 @@ public class TestReadWriteNDSparse extends SharedJavaSparkSession {
             .mode("overwrite");
 
     try {
-      writer.save();
+      writer.save(arrayURI);
       Assert.fail(
           "Duplicate dimensions should not be allowed if set_allows_dups parameter is not set.");
     } catch (Exception e) {
     }
 
-    writer.option("schema.set_allows_dups", true).save();
+    writer.option("schema.set_allows_dups", true).save(arrayURI);
   }
 
   @Test
@@ -163,7 +159,6 @@ public class TestReadWriteNDSparse extends SharedJavaSparkSession {
     DataFrameWriter<Row> writer =
         df.write()
             .format("io.tiledb.spark")
-            .option("uri", arrayURI)
             .option("schema.dim.0.name", "d1")
             .option("schema.dim.0.extent", 2)
             .option("schema.cell_order", "row-major")
@@ -172,13 +167,13 @@ public class TestReadWriteNDSparse extends SharedJavaSparkSession {
             .mode("overwrite");
 
     try {
-      writer.save();
+      writer.save(arrayURI);
       Assert.fail(
           "Duplicate dimensions should not be allowed if set_allows_dups parameter is not set.");
     } catch (Exception e) {
     }
 
-    writer.option("schema.set_allows_dups", true).save();
+    writer.option("schema.set_allows_dups", true).save(arrayURI);
   }
 
   @Test
@@ -207,7 +202,6 @@ public class TestReadWriteNDSparse extends SharedJavaSparkSession {
     DataFrameWriter<Row> writer =
         df.write()
             .format("io.tiledb.spark")
-            .option("uri", arrayURI)
             .option("schema.dim.0.name", "d1")
             .option("schema.dim.0.extent", 2)
             .option("schema.cell_order", "row-major")
@@ -217,12 +211,12 @@ public class TestReadWriteNDSparse extends SharedJavaSparkSession {
             .mode("overwrite");
 
     try {
-      writer.save();
+      writer.save(arrayURI);
       Assert.fail(
           "Duplicate dimensions should not be allowed if set_allows_dups parameter is not set.");
     } catch (Exception e) {
     }
 
-    writer.option("schema.set_allows_dups", true).save();
+    writer.option("schema.set_allows_dups", true).save(arrayURI);
   }
 }

--- a/src/test/java/io/tiledb/spark/TileDBDataSourceOptionsTest.java
+++ b/src/test/java/io/tiledb/spark/TileDBDataSourceOptionsTest.java
@@ -2,8 +2,6 @@ package io.tiledb.spark;
 
 import io.tiledb.java.api.Layout;
 import io.tiledb.java.api.Pair;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,22 +18,14 @@ public class TileDBDataSourceOptionsTest {
     Assert.assertFalse(options.getArrayURI().isPresent());
   }
 
-  @Test(expected = URISyntaxException.class)
-  public void testArrayURIInvalid() throws Exception {
-    HashMap<String, String> optionMap = new HashMap<>();
-    optionMap.put("uri", "s3://$%foo/baz/");
-    TileDBDataSourceOptions options = new TileDBDataSourceOptions(new DataSourceOptions(optionMap));
-    Optional<URI> uri = options.getArrayURI();
-  }
-
   @Test
   public void testArrayURIOption() throws Exception {
     HashMap<String, String> optionMap = new HashMap<>();
     optionMap.put("uri", "s3://foo/bar");
     TileDBDataSourceOptions options = new TileDBDataSourceOptions(new DataSourceOptions(optionMap));
-    Optional<URI> uri = options.getArrayURI();
+    Optional<String> uri = options.getArrayURI();
     Assert.assertTrue(uri.isPresent());
-    Assert.assertEquals(URI.create("s3://foo/bar"), uri.get());
+    Assert.assertEquals("s3://foo/bar", uri.get());
   }
 
   @Test

--- a/src/test/java/io/tiledb/spark/TileDBDataSourceReadMetricsTest.java
+++ b/src/test/java/io/tiledb/spark/TileDBDataSourceReadMetricsTest.java
@@ -26,9 +26,8 @@ public class TileDBDataSourceReadMetricsTest extends SharedJavaSparkSession {
         session()
             .read()
             .format("io.tiledb.spark")
-            .option("uri", testArrayURIString("quickstart_sparse_array"))
             .option("spark.metrics.conf", metricConfigFile())
-            .load();
+            .load(testArrayURIString("quickstart_sparse_array"));
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
     Assert.assertEquals(3, rows.size());

--- a/src/test/java/io/tiledb/spark/TileDBDataSourceReadTest.java
+++ b/src/test/java/io/tiledb/spark/TileDBDataSourceReadTest.java
@@ -155,8 +155,7 @@ public class TileDBDataSourceReadTest extends SharedJavaSparkSession {
         session()
             .read()
             .format("io.tiledb.spark")
-            .option("uri", testArrayURIString("quickstart_sparse_array"))
-            .load();
+            .load(testArrayURIString("quickstart_sparse_array"));
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
     Assert.assertEquals(3, rows.size());
@@ -188,10 +187,9 @@ public class TileDBDataSourceReadTest extends SharedJavaSparkSession {
           session()
               .read()
               .format("io.tiledb.spark")
-              .option("uri", DENSE_ARRAY_URI)
               .option("order", order)
               .option("partition_count", 1)
-              .load();
+              .load(DENSE_ARRAY_URI);
       dfRead.createOrReplaceTempView("tmp");
       List<Row> rows = dfRead.sqlContext().sql("SELECT * FROM tmp").collectAsList();
       int[] expectedRows = new int[] {1, 1, 2, 2, 3, 3, 4, 4};
@@ -236,10 +234,9 @@ public class TileDBDataSourceReadTest extends SharedJavaSparkSession {
           session()
               .read()
               .format("io.tiledb.spark")
-              .option("uri", SPARSE_ARRAY_URI)
               .option("order", order)
               .option("partition_count", 1)
-              .load();
+              .load(SPARSE_ARRAY_URI);
       dfRead.createOrReplaceTempView("tmp");
       dfRead.show();
       List<Row> rows = dfRead.sqlContext().sql("SELECT * FROM tmp").collectAsList();
@@ -284,10 +281,9 @@ public class TileDBDataSourceReadTest extends SharedJavaSparkSession {
           session()
               .read()
               .format("io.tiledb.spark")
-              .option("uri", SPARSE_ARRAY_URI)
               .option("order", order)
               .option("partition_count", 1)
-              .load();
+              .load(SPARSE_ARRAY_URI);
       dfRead.createOrReplaceTempView("tmp");
       dfRead.show();
       List<Row> rows1 = dfRead.sqlContext().sql("SELECT * FROM tmp").collectAsList();
@@ -405,10 +401,9 @@ public class TileDBDataSourceReadTest extends SharedJavaSparkSession {
           session()
               .read()
               .format("io.tiledb.spark")
-              .option("uri", SPARSE_ARRAY_URI)
               .option("order", order)
               .option("partition_count", 1)
-              .load();
+              .load(SPARSE_ARRAY_URI);
       dfRead.createOrReplaceTempView("tmp");
       dfRead.show();
       List<Row> rows = dfRead.sqlContext().sql("SELECT * FROM tmp").collectAsList();

--- a/src/test/java/io/tiledb/spark/TileDBDataSourceReadTestBufferSizes.java
+++ b/src/test/java/io/tiledb/spark/TileDBDataSourceReadTestBufferSizes.java
@@ -25,9 +25,8 @@ public class TileDBDataSourceReadTestBufferSizes extends SharedJavaSparkSession 
         session()
             .read()
             .format("io.tiledb.spark")
-            .option("uri", testArrayURIString("quickstart_sparse_array"))
             .option("read_buffer_size", 8)
-            .load();
+            .load(testArrayURIString("quickstart_sparse_array"));
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
     Assert.assertEquals(3, rows.size());

--- a/src/test/java/io/tiledb/spark/TileDBDataSourceReadTestPartitioning.java
+++ b/src/test/java/io/tiledb/spark/TileDBDataSourceReadTestPartitioning.java
@@ -23,8 +23,7 @@ public class TileDBDataSourceReadTestPartitioning extends SharedJavaSparkSession
             .read()
             .format("io.tiledb.spark")
             .option("partition_count", 11)
-            .option("uri", testArrayURIString("sparse_large_dimension_1_4000"))
-            .load();
+            .load(testArrayURIString("sparse_large_dimension_1_4000"));
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp ORDER BY rows, cols").collectAsList();
     Assert.assertEquals(8, rows.size());
@@ -79,8 +78,7 @@ public class TileDBDataSourceReadTestPartitioning extends SharedJavaSparkSession
             .read()
             .format("io.tiledb.spark")
             .option("partition_count", 11)
-            .option("uri", testArrayURIString("sparse_large_dimension_1_4000"))
-            .load();
+            .load(testArrayURIString("sparse_large_dimension_1_4000"));
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows =
         session()
@@ -139,8 +137,7 @@ public class TileDBDataSourceReadTestPartitioning extends SharedJavaSparkSession
             .read()
             .format("io.tiledb.spark")
             .option("partition_count", 1)
-            .option("uri", testArrayURIString("sparse_large_dimension_1_4000"))
-            .load();
+            .load(testArrayURIString("sparse_large_dimension_1_4000"));
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
     Assert.assertEquals(8, rows.size());

--- a/src/test/java/io/tiledb/spark/TimeTravellingTest.java
+++ b/src/test/java/io/tiledb/spark/TimeTravellingTest.java
@@ -164,8 +164,7 @@ public class TimeTravellingTest extends SharedJavaSparkSession {
         .format("io.tiledb.spark")
         .option("timestamp_start", timestamp_start)
         .option("timestamp_end", timestamp_end)
-        .option("uri", arrayURI)
-        .load();
+        .load(arrayURI);
   }
 
   public void arrayCreate() throws Exception {

--- a/src/test/java/io/tiledb/spark/VarAttributesTest.java
+++ b/src/test/java/io/tiledb/spark/VarAttributesTest.java
@@ -113,7 +113,7 @@ public class VarAttributesTest extends SharedJavaSparkSession {
   public void denseArrayReadTest() throws Exception {
     arrayCreate();
     arrayWrite();
-    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").option("uri", URI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(URI);
     dfRead.show();
     dfRead.createOrReplaceTempView("tmp");
     List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();

--- a/src/test/java/io/tiledb/spark/WriteSparkDataTypesTest.java
+++ b/src/test/java/io/tiledb/spark/WriteSparkDataTypesTest.java
@@ -25,13 +25,12 @@ public class WriteSparkDataTypesTest extends SharedJavaSparkSession implements S
     dfWrite
         .write()
         .format("io.tiledb.spark")
-        .option("uri", arrayURI)
         .option("schema.dim.0.name", "id")
         .mode("overwrite")
-        .save();
+        .save(arrayURI);
 
     // read saved byte dataset
-    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").option("uri", arrayURI).load();
+    Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(arrayURI);
     dfRead.show();
     Assert.assertEquals(dfWrite.count(), dfRead.count());
     Assert.assertTrue(assertDataFrameEquals(dfWrite, dfRead));


### PR DESCRIPTION
This PR makes the TileDB URI  a parameter of load()/save() as it should be based on the Spark documentation for external sources. Passing the URI as an "option" is still working, so current users of the connector do not need to make any changes. 