### PR TITLE
Adding metadata read/write support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,19 +86,22 @@ to `$SPARK_HOME/jars/`.
 * `legacy_reader` (optional): Use the legacy reader that does not use Apache Arrow Buffers: False
 * `timestamp_start`(optional): The start timestamp at which to open the array
 * `timestamp_end`(optional): The end timestamp at which to open the array
+* `print_array_metadata`(optional): Prints the array metadata to the console
 
 ### Write options
 * `write_buffer_size` (optional): Set the TileDB read buffer size in bytes per attribute/coordinates. Defaults to 10MB
-* `schema.dim.<N>.name` (requried): Specify which of the spark dataframe columns names are dimensions.
-* `schema.dim.<N>.min` (optional): Specify the lower bound for the TileDB array schema.
-* `schema.dim.<N>.max` (optional): Specify the upper bound for the TileDB array schema.
-* `schema.dim.<N>.extent` (optional): Specify the schema dimension domain extent (tile size).
+* `schema.dim.<N>.name` (requried): Specify which of the spark dataframe columns names are dimensions
+* `schema.dim.<N>.min` (optional): Specify the lower bound for the TileDB array schema
+* `schema.dim.<N>.max` (optional): Specify the upper bound for the TileDB array schema
+* `schema.dim.<N>.extent` (optional): Specify the schema dimension domain extent (tile size)
 * `schema.attr.<NAME>.filter_list` (optional): Specfify filter list for attribute NAME.  Filter list is a tuple of the form `(name, option)`, ex: `"(byteshuffle, -1), (gzip, 9)"`
-* `schema.capacity` (optional): Specify the sparse array tile capacity.
+* `schema.capacity` (optional): Specify the sparse array tile capacity
 * `schema.cell_order` (optional): Specify the cell order. Filter list is a tuple of the form `(name, option)`, ex: `"(byteshuffle, -1), (gzip, 9)"`
 * `schema.tile_order` (optional): Specify the tile order. Filter list is a tuple of the form `(name, option)`, ex: `"(byteshuffle, -1), (gzip, 9)"`
-* `schema.coords_filter_list` (optional): Specify the coordinate filter list.
-* `schema.offsets_filter_list` (optional): Specify the offsets filter list.
+* `schema.coords_filter_list` (optional): Specify the coordinate filter list
+* `schema.offsets_filter_list` (optional): Specify the offsets filter list
+* `metadata_value.<KEY>` (optional): The metadata value for a given key
+* `metadata_type.<KEY>` (optional): The metadata datatype for a given key
 
 ## Semantics
 

--- a/src/main/java/io/tiledb/spark/TileDBDataSourceOptions.java
+++ b/src/main/java/io/tiledb/spark/TileDBDataSourceOptions.java
@@ -69,6 +69,14 @@ public class TileDBDataSourceOptions implements Serializable {
     return false;
   }
 
+  /** @return True if only the array metadata is requested * */
+  public boolean printMetadata() {
+    if (optionMap.containsKey("print_array_metadata")) {
+      return Boolean.parseBoolean(optionMap.get("print_array_metadata"));
+    }
+    return false;
+  }
+
   /** @return partition count * */
   public int getPartitionCount() {
     if (optionMap.containsKey("partition_count")) {

--- a/src/main/java/io/tiledb/spark/TileDBDataSourceOptions.java
+++ b/src/main/java/io/tiledb/spark/TileDBDataSourceOptions.java
@@ -140,6 +140,20 @@ public class TileDBDataSourceOptions implements Serializable {
     return Optional.of(schemaDimensions);
   }
 
+  /** @return A map with the metadata keys and values */
+  public Map<String, String> getMetadata() {
+    Map<String, String> results =
+        collectOptionsWithKeyPrefixSuffixMap(optionMap, "metadata_value.", null);
+    return results;
+  }
+
+  /** @return A map with the metadata keys and datatypes */
+  public Map<String, String> getMetadataTypes() {
+    Map<String, String> results =
+        collectOptionsWithKeyPrefixSuffixMap(optionMap, "metadata_type.", null);
+    return results;
+  }
+
   /**
    * Returns the timestamp start necessary for time travelling in intervals.
    *
@@ -441,6 +455,41 @@ public class TileDBDataSourceOptions implements Serializable {
               strippedKeyPrefix.substring(0, strippedKeyPrefix.length() - suffix.length());
           if (strippedKeySuffix.length() > 0) {
             results.add(new Pair<>(strippedKeySuffix, val));
+          }
+        }
+      }
+    }
+    return results;
+  }
+
+  private static Map<String, String> collectOptionsWithKeyPrefixSuffixMap(
+      Map<String, String> options, String prefix, String suffix) {
+    Map<String, String> results = new HashMap<>();
+    boolean hasPrefix = (prefix != null && prefix.length() > 0);
+    boolean hasSuffix = (suffix != null && suffix.length() > 0);
+    if (options.isEmpty() || !hasPrefix) {
+      return results;
+    }
+    Iterator<Map.Entry<String, String>> entries = options.entrySet().iterator();
+    while (entries.hasNext()) {
+      Map.Entry<String, String> entry = entries.next();
+      String key = entry.getKey();
+      String val = entry.getValue();
+      if (key.startsWith(prefix)) {
+        String strippedKeyPrefix = key.substring(prefix.length());
+        if (strippedKeyPrefix.length() == 0) {
+          continue;
+        }
+        if (!hasSuffix) {
+          results.put(strippedKeyPrefix, val);
+          continue;
+        }
+        // check suffix
+        if (key.endsWith(suffix)) {
+          String strippedKeySuffix =
+              strippedKeyPrefix.substring(0, strippedKeyPrefix.length() - suffix.length());
+          if (strippedKeySuffix.length() > 0) {
+            results.put(strippedKeySuffix, val);
           }
         }
       }


### PR DESCRIPTION
Referencing: [add array metadata support](https://app.shortcut.com/tiledb-inc/story/628/add-array-metadata-support?ct_workflow=all) [sc-628]



# Read support:
Simple printing of the metadata

Example:
  ```
Dataset<Row> df =
      session()
          .read()
          .format("io.tiledb.spark")
          .option("print_array_metadata", true)
          .load(tempWrite);
```

# Write support:
Users will now be able to pass metadata to their TileDB arrays by using the dataframe options before saving.

Example:

       df
        .write()
        .format("io.tiledb.spark")
        .option("uri", tempWrite)
        .option("schema.dim.0.name", "rows")
        .option("schema.dim.0.min", 1)
        .option("schema.dim.0.max", 2)
        .option("schema.dim.0.extent", 2)
        .option("schema.dim.1.name", "cols")
        .option("schema.dim.1.min", 1)
        .option("schema.dim.1.max", 2)
        .option("schema.dim.1.extent", 2)
        .option("schema.cell_order", "row-major")
        .option("schema.tile_order", "row-major")
        .option("metadata_value.key1", 15)
        .option("metadata_type.key1", "TILEDB_INT32")
        .option("metadata_value.key2", 25.0f)
        .option("metadata_type.key2", "TILEDB_FLOAT32")
        .option("metadata_value.key3", "String25")
        .option("metadata_type.key3", "TILEDB_STRING_ASCII")
        .mode("overwrite")
        .save();

# Currently supported types:

TILEDB_STRING_ASCII, TILEDB_INT32, TILEDB_FLOAT32
