### PR TITLE
Dimitrisstaratzis/sc 19175/pushdown or

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ to `$SPARK_HOME/jars/`.
 * `timestamp_start`(optional): The start timestamp at which to open the array
 * `timestamp_end`(optional): The end timestamp at which to open the array
 * `print_array_metadata`(optional): Prints the array metadata to the console
+* `tiledb_filtering`(optional): If false, disables the use of TileDB's Query Condition API and uses Spark filtering
 
 ### Write options
 * `write_buffer_size` (optional): Set the TileDB read buffer size in bytes per attribute/coordinates. Defaults to 10MB

--- a/src/main/java/io/tiledb/spark/TileDBBatch.java
+++ b/src/main/java/io/tiledb/spark/TileDBBatch.java
@@ -265,7 +265,7 @@ public class TileDBBatch implements Batch {
       QueryCondition leftQc = left.getSecond();
       QueryCondition rightQc = right.getSecond();
       if (leftQc != null && rightQc != null) {
-        finalQc = leftQc.combine(rightQc, TILEDB_OR);
+        finalQc = leftQc.combine(rightQc, TILEDB_AND);
         // close unneeded query conditions
         leftQc.close();
         rightQc.close();

--- a/src/main/java/io/tiledb/spark/TileDBDataSourceOptions.java
+++ b/src/main/java/io/tiledb/spark/TileDBDataSourceOptions.java
@@ -61,6 +61,14 @@ public class TileDBDataSourceOptions implements Serializable {
     return true;
   }
 
+  /** @return Disable filtering by TileDB's Query Condition * */
+  public boolean getTileDBFiltering() {
+    if (optionMap.containsKey("tiledb_filtering")) {
+      return Boolean.parseBoolean(optionMap.get("tiledb_filtering"));
+    }
+    return true;
+  }
+
   /** @return True if the legacy non-arrow reader is requested * */
   public boolean getLegacyReader() {
     if (optionMap.containsKey("legacy_reader")) {

--- a/src/main/java/io/tiledb/spark/TileDBScan.java
+++ b/src/main/java/io/tiledb/spark/TileDBScan.java
@@ -2,6 +2,8 @@ package io.tiledb.spark;
 
 import static org.apache.spark.metrics.TileDBMetricsSource.dataSourceReadSchemaTimerName;
 
+import io.tiledb.java.api.TileDBError;
+import java.net.URISyntaxException;
 import org.apache.log4j.Logger;
 import org.apache.spark.TaskContext;
 import org.apache.spark.metrics.TileDBReadMetricsUpdater;
@@ -48,7 +50,11 @@ public class TileDBScan implements Scan {
 
   @Override
   public Batch toBatch() {
-    return new TileDBBatch(tileDBReadSchema, options, pushedFilters);
+    try {
+      return new TileDBBatch(tileDBReadSchema, options, pushedFilters);
+    } catch (TileDBError | URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/src/main/java/io/tiledb/spark/TileDBScanBuilder.java
+++ b/src/main/java/io/tiledb/spark/TileDBScanBuilder.java
@@ -80,6 +80,7 @@ public class TileDBScanBuilder
   }
 
   private boolean filterCanBePushedDown(Filter filter) {
+    if (!options.getTileDBFiltering()) return false;
     if (filter instanceof And) {
       And f = (And) filter;
       return filterCanBePushedDown(f.left()) && filterCanBePushedDown(f.right());

--- a/src/main/java/io/tiledb/spark/TileDBScanBuilder.java
+++ b/src/main/java/io/tiledb/spark/TileDBScanBuilder.java
@@ -13,14 +13,7 @@ import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.SupportsPushDownFilters;
 import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
-import org.apache.spark.sql.sources.And;
-import org.apache.spark.sql.sources.EqualNullSafe;
-import org.apache.spark.sql.sources.EqualTo;
-import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.sources.GreaterThan;
-import org.apache.spark.sql.sources.GreaterThanOrEqual;
-import org.apache.spark.sql.sources.LessThan;
-import org.apache.spark.sql.sources.LessThanOrEqual;
+import org.apache.spark.sql.sources.*;
 import org.apache.spark.sql.types.StructType;
 
 public class TileDBScanBuilder
@@ -89,9 +82,7 @@ public class TileDBScanBuilder
   private boolean filterCanBePushedDown(Filter filter) {
     if (filter instanceof And) {
       And f = (And) filter;
-      if (filterCanBePushedDown(f.left()) && filterCanBePushedDown(f.right())) {
-        return true;
-      }
+      return filterCanBePushedDown(f.left()) && filterCanBePushedDown(f.right());
     } else if (filter instanceof EqualNullSafe) {
       return true;
     } else if (filter instanceof EqualTo) {
@@ -104,6 +95,9 @@ public class TileDBScanBuilder
       return true;
     } else if (filter instanceof LessThanOrEqual) {
       return true;
+    } else if (filter instanceof Or) {
+      Or f = (Or) filter;
+      return filterCanBePushedDown(f.left()) && filterCanBePushedDown(f.right());
     }
     return false;
   }

--- a/src/test/java/io/tiledb/spark/TileDBDataSourceReadTest.java
+++ b/src/test/java/io/tiledb/spark/TileDBDataSourceReadTest.java
@@ -310,9 +310,14 @@ public class TileDBDataSourceReadTest extends SharedJavaSparkSession {
               .sqlContext()
               .sql("SELECT * FROM tmp WHERE (d2 > 20 AND a1 > 9) OR a2 = 100")
               .collectAsList(); // is pushed down
+      List<Row> rows6 =
+          dfRead
+              .sqlContext()
+              .sql("SELECT * FROM tmp WHERE (a1 > 20 AND a1 < 30) OR (a2 > 250 AND a2 < 2000)")
+              .collectAsList(); // is pushed down
 
       //      for (int i = 0; i < rows3.size(); i++) {
-      //        System.out.println(rows3.get(i).getInt(3));
+      //        System.out.println(rows6.get(i).getInt(3));
       //      }
 
       String[] d1 = new String[] {"object1", "object2", "object3"};
@@ -374,6 +379,18 @@ public class TileDBDataSourceReadTest extends SharedJavaSparkSession {
         Assert.assertEquals(d2[i], rows5.get(i).getInt(1));
         Assert.assertEquals(a1[i], rows5.get(i).getInt(2));
         Assert.assertEquals(a2[i], rows5.get(i).getInt(3));
+      }
+
+      d1 = new String[] {"object2", "object3"};
+      d2 = new int[] {40, 50};
+      a1 = new int[] {23, 30};
+      a2 = new int[] {230, 300};
+      Assert.assertEquals(rows6.size(), d1.length);
+      for (int i = 0; i < rows6.size(); i++) {
+        Assert.assertEquals(d1[i], rows6.get(i).getString(0));
+        Assert.assertEquals(d2[i], rows6.get(i).getInt(1));
+        Assert.assertEquals(a1[i], rows6.get(i).getInt(2));
+        Assert.assertEquals(a2[i], rows6.get(i).getInt(3));
       }
     }
   }

--- a/src/test/java/io/tiledb/spark/TileDBDataSourceReadTest.java
+++ b/src/test/java/io/tiledb/spark/TileDBDataSourceReadTest.java
@@ -276,98 +276,100 @@ public class TileDBDataSourceReadTest extends SharedJavaSparkSession {
     sparseHeterogeneousArrayCreate2A(dimensions);
     sparseHeterogeneousArrayWrite(data);
 
-    for (String order : new String[] {"row-major", "TILEDB_ROW_MAJOR"}) {
-      Dataset<Row> dfRead =
-          session()
-              .read()
-              .format("io.tiledb.spark")
-              .option("order", order)
-              .option("partition_count", 1)
-              .load(SPARSE_ARRAY_URI);
-      dfRead.createOrReplaceTempView("tmp");
-      dfRead.show();
-      List<Row> rows1 = dfRead.sqlContext().sql("SELECT * FROM tmp").collectAsList();
-      List<Row> rows2 =
-          dfRead
-              .sqlContext()
-              .sql("SELECT * FROM tmp WHERE a1 > 25")
-              .collectAsList(); // is pushed down
-      List<Row> rows3 =
-          dfRead
-              .sqlContext()
-              .sql("SELECT * FROM tmp WHERE a1 >= 23")
-              .collectAsList(); // is pushed down
-      List<Row> rows4 =
-          dfRead
-              .sqlContext()
-              .sql("SELECT * FROM tmp WHERE a1 > 25 or a1 < 20")
-              .collectAsList(); // is not pushed down
-      List<Row> rows5 =
-          dfRead
-              .sqlContext()
-              .sql("SELECT * FROM tmp WHERE a1 > 25 AND a2 > 250")
-              .collectAsList(); // is pushed down
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.spark")
+            .option("order", "row-major")
+            .option("partition_count", 2)
+            .load(SPARSE_ARRAY_URI);
+    dfRead.createOrReplaceTempView("tmp");
+    dfRead.show();
+    List<Row> rows1 = dfRead.sqlContext().sql("SELECT * FROM tmp").collectAsList();
+    List<Row> rows2 =
+        dfRead
+            .sqlContext()
+            .sql("SELECT * FROM tmp WHERE a2 >= 100 AND a1 > 25 ")
+            .collectAsList(); // is pushed down
+    List<Row> rows3 =
+        dfRead
+            .sqlContext()
+            .sql("SELECT * FROM tmp WHERE a1 >= 24 OR a1 = 23")
+            .collectAsList(); // is pushed down
+    List<Row> rows4 =
+        dfRead
+            .sqlContext()
+            .sql("SELECT * FROM tmp WHERE (a1 > 25 OR a1 < 20) AND a2 = 300")
+            .collectAsList(); // is not pushed down
+    List<Row> rows5 =
+        dfRead
+            .sqlContext()
+            .sql("SELECT * FROM tmp WHERE (d2 > 20 AND a1 > 9) OR a2 = 100")
+            .collectAsList(); // is pushed down
 
-      String[] d1 = new String[] {"object1", "object2", "object3"};
-      int[] d2 = new int[] {12, 40, 50};
-      int[] a1 = new int[] {10, 23, 30};
-      int[] a2 = new int[] {100, 230, 300};
+    //      for (int i = 0; i < rows3.size(); i++) {
+    //        System.out.println(rows3.get(i).getInt(3));
+    //      }
 
-      Assert.assertEquals(rows1.size(), d1.length);
-      for (int i = 0; i < rows1.size(); i++) {
-        Assert.assertEquals(d1[i], rows1.get(i).getString(0));
-        Assert.assertEquals(d2[i], rows1.get(i).getInt(1));
-        Assert.assertEquals(a1[i], rows1.get(i).getInt(2));
-        Assert.assertEquals(a2[i], rows1.get(i).getInt(3));
-      }
+    String[] d1 = new String[] {"object1", "object2", "object3"};
+    int[] d2 = new int[] {12, 40, 50};
+    int[] a1 = new int[] {10, 23, 30};
+    int[] a2 = new int[] {100, 230, 300};
 
-      d1 = new String[] {"object3"};
-      d2 = new int[] {50};
-      a1 = new int[] {30};
-      a2 = new int[] {300};
-      Assert.assertEquals(rows2.size(), d1.length);
-      for (int i = 0; i < rows2.size(); i++) {
-        Assert.assertEquals(d1[i], rows2.get(i).getString(0));
-        Assert.assertEquals(d2[i], rows2.get(i).getInt(1));
-        Assert.assertEquals(a1[i], rows2.get(i).getInt(2));
-        Assert.assertEquals(a2[i], rows2.get(i).getInt(3));
-      }
+    Assert.assertEquals(rows1.size(), d1.length);
+    for (int i = 0; i < rows1.size(); i++) {
+      Assert.assertEquals(d1[i], rows1.get(i).getString(0));
+      Assert.assertEquals(d2[i], rows1.get(i).getInt(1));
+      Assert.assertEquals(a1[i], rows1.get(i).getInt(2));
+      Assert.assertEquals(a2[i], rows1.get(i).getInt(3));
+    }
 
-      d1 = new String[] {"object2", "object3"};
-      d2 = new int[] {40, 50};
-      a1 = new int[] {23, 30};
-      a2 = new int[] {230, 300};
-      Assert.assertEquals(rows3.size(), d1.length);
-      for (int i = 0; i < rows3.size(); i++) {
-        Assert.assertEquals(d1[i], rows3.get(i).getString(0));
-        Assert.assertEquals(d2[i], rows3.get(i).getInt(1));
-        Assert.assertEquals(a1[i], rows3.get(i).getInt(2));
-        Assert.assertEquals(a2[i], rows3.get(i).getInt(3));
-      }
+    d1 = new String[] {"object3"};
+    d2 = new int[] {50};
+    a1 = new int[] {30};
+    a2 = new int[] {300};
+    Assert.assertEquals(rows2.size(), d1.length);
+    for (int i = 0; i < rows2.size(); i++) {
+      Assert.assertEquals(d1[i], rows2.get(i).getString(0));
+      Assert.assertEquals(d2[i], rows2.get(i).getInt(1));
+      Assert.assertEquals(a1[i], rows2.get(i).getInt(2));
+      Assert.assertEquals(a2[i], rows2.get(i).getInt(3));
+    }
 
-      d1 = new String[] {"object1", "object3"};
-      d2 = new int[] {12, 50};
-      a1 = new int[] {10, 30};
-      a2 = new int[] {100, 300};
-      Assert.assertEquals(rows4.size(), d1.length);
-      for (int i = 0; i < rows4.size(); i++) {
-        Assert.assertEquals(d1[i], rows4.get(i).getString(0));
-        Assert.assertEquals(d2[i], rows4.get(i).getInt(1));
-        Assert.assertEquals(a1[i], rows4.get(i).getInt(2));
-        Assert.assertEquals(a2[i], rows4.get(i).getInt(3));
-      }
+    d1 = new String[] {"object2", "object3"};
+    d2 = new int[] {40, 50};
+    a1 = new int[] {23, 30};
+    a2 = new int[] {230, 300};
+    Assert.assertEquals(rows3.size(), d1.length);
+    for (int i = 0; i < rows3.size(); i++) {
+      Assert.assertEquals(d1[i], rows3.get(i).getString(0));
+      Assert.assertEquals(d2[i], rows3.get(i).getInt(1));
+      Assert.assertEquals(a1[i], rows3.get(i).getInt(2));
+      Assert.assertEquals(a2[i], rows3.get(i).getInt(3));
+    }
 
-      d1 = new String[] {"object3"};
-      d2 = new int[] {50};
-      a1 = new int[] {30};
-      a2 = new int[] {300};
-      Assert.assertEquals(rows5.size(), d1.length);
-      for (int i = 0; i < rows5.size(); i++) {
-        Assert.assertEquals(d1[i], rows5.get(i).getString(0));
-        Assert.assertEquals(d2[i], rows5.get(i).getInt(1));
-        Assert.assertEquals(a1[i], rows5.get(i).getInt(2));
-        Assert.assertEquals(a2[i], rows5.get(i).getInt(3));
-      }
+    d1 = new String[] {"object3"};
+    d2 = new int[] {50};
+    a1 = new int[] {30};
+    a2 = new int[] {300};
+    Assert.assertEquals(rows4.size(), d1.length);
+    for (int i = 0; i < rows4.size(); i++) {
+      Assert.assertEquals(d1[i], rows4.get(i).getString(0));
+      Assert.assertEquals(d2[i], rows4.get(i).getInt(1));
+      Assert.assertEquals(a1[i], rows4.get(i).getInt(2));
+      Assert.assertEquals(a2[i], rows4.get(i).getInt(3));
+    }
+
+    d1 = new String[] {"object1", "object2", "object3"};
+    d2 = new int[] {12, 40, 50};
+    a1 = new int[] {10, 23, 30};
+    a2 = new int[] {100, 230, 300};
+    Assert.assertEquals(rows5.size(), d1.length);
+    for (int i = 0; i < rows5.size(); i++) {
+      Assert.assertEquals(d1[i], rows5.get(i).getString(0));
+      Assert.assertEquals(d2[i], rows5.get(i).getInt(1));
+      Assert.assertEquals(a1[i], rows5.get(i).getInt(2));
+      Assert.assertEquals(a2[i], rows5.get(i).getInt(3));
     }
   }
 

--- a/src/test/java/io/tiledb/spark/TileDBDataSourceReadTest.java
+++ b/src/test/java/io/tiledb/spark/TileDBDataSourceReadTest.java
@@ -276,100 +276,105 @@ public class TileDBDataSourceReadTest extends SharedJavaSparkSession {
     sparseHeterogeneousArrayCreate2A(dimensions);
     sparseHeterogeneousArrayWrite(data);
 
-    Dataset<Row> dfRead =
-        session()
-            .read()
-            .format("io.tiledb.spark")
-            .option("order", "row-major")
-            .option("partition_count", 2)
-            .load(SPARSE_ARRAY_URI);
-    dfRead.createOrReplaceTempView("tmp");
-    dfRead.show();
-    List<Row> rows1 = dfRead.sqlContext().sql("SELECT * FROM tmp").collectAsList();
-    List<Row> rows2 =
-        dfRead
-            .sqlContext()
-            .sql("SELECT * FROM tmp WHERE a2 >= 100 AND a1 > 25 ")
-            .collectAsList(); // is pushed down
-    List<Row> rows3 =
-        dfRead
-            .sqlContext()
-            .sql("SELECT * FROM tmp WHERE a1 >= 24 OR a1 = 23")
-            .collectAsList(); // is pushed down
-    List<Row> rows4 =
-        dfRead
-            .sqlContext()
-            .sql("SELECT * FROM tmp WHERE (a1 > 25 OR a1 < 20) AND a2 = 300")
-            .collectAsList(); // is not pushed down
-    List<Row> rows5 =
-        dfRead
-            .sqlContext()
-            .sql("SELECT * FROM tmp WHERE (d2 > 20 AND a1 > 9) OR a2 = 100")
-            .collectAsList(); // is pushed down
+    // Run with Query Condition on/off
+    Boolean[] tiledbFiltering = {true, false};
+    for (Boolean flag : tiledbFiltering) {
+      Dataset<Row> dfRead =
+          session()
+              .read()
+              .format("io.tiledb.spark")
+              .option("order", "row-major")
+              .option("partition_count", 2)
+              .option("tiledb_filtering", flag)
+              .load(SPARSE_ARRAY_URI);
+      dfRead.createOrReplaceTempView("tmp");
+      dfRead.show();
+      List<Row> rows1 = dfRead.sqlContext().sql("SELECT * FROM tmp").collectAsList();
+      List<Row> rows2 =
+          dfRead
+              .sqlContext()
+              .sql("SELECT * FROM tmp WHERE a2 >= 100 AND a1 > 25 ")
+              .collectAsList(); // is pushed down
+      List<Row> rows3 =
+          dfRead
+              .sqlContext()
+              .sql("SELECT * FROM tmp WHERE a1 >= 24 OR a1 = 23")
+              .collectAsList(); // is pushed down
+      List<Row> rows4 =
+          dfRead
+              .sqlContext()
+              .sql("SELECT * FROM tmp WHERE (a1 > 25 OR a1 < 20) AND a2 = 300")
+              .collectAsList(); // is not pushed down
+      List<Row> rows5 =
+          dfRead
+              .sqlContext()
+              .sql("SELECT * FROM tmp WHERE (d2 > 20 AND a1 > 9) OR a2 = 100")
+              .collectAsList(); // is pushed down
 
-    //      for (int i = 0; i < rows3.size(); i++) {
-    //        System.out.println(rows3.get(i).getInt(3));
-    //      }
+      //      for (int i = 0; i < rows3.size(); i++) {
+      //        System.out.println(rows3.get(i).getInt(3));
+      //      }
 
-    String[] d1 = new String[] {"object1", "object2", "object3"};
-    int[] d2 = new int[] {12, 40, 50};
-    int[] a1 = new int[] {10, 23, 30};
-    int[] a2 = new int[] {100, 230, 300};
+      String[] d1 = new String[] {"object1", "object2", "object3"};
+      int[] d2 = new int[] {12, 40, 50};
+      int[] a1 = new int[] {10, 23, 30};
+      int[] a2 = new int[] {100, 230, 300};
 
-    Assert.assertEquals(rows1.size(), d1.length);
-    for (int i = 0; i < rows1.size(); i++) {
-      Assert.assertEquals(d1[i], rows1.get(i).getString(0));
-      Assert.assertEquals(d2[i], rows1.get(i).getInt(1));
-      Assert.assertEquals(a1[i], rows1.get(i).getInt(2));
-      Assert.assertEquals(a2[i], rows1.get(i).getInt(3));
-    }
+      Assert.assertEquals(rows1.size(), d1.length);
+      for (int i = 0; i < rows1.size(); i++) {
+        Assert.assertEquals(d1[i], rows1.get(i).getString(0));
+        Assert.assertEquals(d2[i], rows1.get(i).getInt(1));
+        Assert.assertEquals(a1[i], rows1.get(i).getInt(2));
+        Assert.assertEquals(a2[i], rows1.get(i).getInt(3));
+      }
 
-    d1 = new String[] {"object3"};
-    d2 = new int[] {50};
-    a1 = new int[] {30};
-    a2 = new int[] {300};
-    Assert.assertEquals(rows2.size(), d1.length);
-    for (int i = 0; i < rows2.size(); i++) {
-      Assert.assertEquals(d1[i], rows2.get(i).getString(0));
-      Assert.assertEquals(d2[i], rows2.get(i).getInt(1));
-      Assert.assertEquals(a1[i], rows2.get(i).getInt(2));
-      Assert.assertEquals(a2[i], rows2.get(i).getInt(3));
-    }
+      d1 = new String[] {"object3"};
+      d2 = new int[] {50};
+      a1 = new int[] {30};
+      a2 = new int[] {300};
+      Assert.assertEquals(rows2.size(), d1.length);
+      for (int i = 0; i < rows2.size(); i++) {
+        Assert.assertEquals(d1[i], rows2.get(i).getString(0));
+        Assert.assertEquals(d2[i], rows2.get(i).getInt(1));
+        Assert.assertEquals(a1[i], rows2.get(i).getInt(2));
+        Assert.assertEquals(a2[i], rows2.get(i).getInt(3));
+      }
 
-    d1 = new String[] {"object2", "object3"};
-    d2 = new int[] {40, 50};
-    a1 = new int[] {23, 30};
-    a2 = new int[] {230, 300};
-    Assert.assertEquals(rows3.size(), d1.length);
-    for (int i = 0; i < rows3.size(); i++) {
-      Assert.assertEquals(d1[i], rows3.get(i).getString(0));
-      Assert.assertEquals(d2[i], rows3.get(i).getInt(1));
-      Assert.assertEquals(a1[i], rows3.get(i).getInt(2));
-      Assert.assertEquals(a2[i], rows3.get(i).getInt(3));
-    }
+      d1 = new String[] {"object2", "object3"};
+      d2 = new int[] {40, 50};
+      a1 = new int[] {23, 30};
+      a2 = new int[] {230, 300};
+      Assert.assertEquals(rows3.size(), d1.length);
+      for (int i = 0; i < rows3.size(); i++) {
+        Assert.assertEquals(d1[i], rows3.get(i).getString(0));
+        Assert.assertEquals(d2[i], rows3.get(i).getInt(1));
+        Assert.assertEquals(a1[i], rows3.get(i).getInt(2));
+        Assert.assertEquals(a2[i], rows3.get(i).getInt(3));
+      }
 
-    d1 = new String[] {"object3"};
-    d2 = new int[] {50};
-    a1 = new int[] {30};
-    a2 = new int[] {300};
-    Assert.assertEquals(rows4.size(), d1.length);
-    for (int i = 0; i < rows4.size(); i++) {
-      Assert.assertEquals(d1[i], rows4.get(i).getString(0));
-      Assert.assertEquals(d2[i], rows4.get(i).getInt(1));
-      Assert.assertEquals(a1[i], rows4.get(i).getInt(2));
-      Assert.assertEquals(a2[i], rows4.get(i).getInt(3));
-    }
+      d1 = new String[] {"object3"};
+      d2 = new int[] {50};
+      a1 = new int[] {30};
+      a2 = new int[] {300};
+      Assert.assertEquals(rows4.size(), d1.length);
+      for (int i = 0; i < rows4.size(); i++) {
+        Assert.assertEquals(d1[i], rows4.get(i).getString(0));
+        Assert.assertEquals(d2[i], rows4.get(i).getInt(1));
+        Assert.assertEquals(a1[i], rows4.get(i).getInt(2));
+        Assert.assertEquals(a2[i], rows4.get(i).getInt(3));
+      }
 
-    d1 = new String[] {"object1", "object2", "object3"};
-    d2 = new int[] {12, 40, 50};
-    a1 = new int[] {10, 23, 30};
-    a2 = new int[] {100, 230, 300};
-    Assert.assertEquals(rows5.size(), d1.length);
-    for (int i = 0; i < rows5.size(); i++) {
-      Assert.assertEquals(d1[i], rows5.get(i).getString(0));
-      Assert.assertEquals(d2[i], rows5.get(i).getInt(1));
-      Assert.assertEquals(a1[i], rows5.get(i).getInt(2));
-      Assert.assertEquals(a2[i], rows5.get(i).getInt(3));
+      d1 = new String[] {"object1", "object2", "object3"};
+      d2 = new int[] {12, 40, 50};
+      a1 = new int[] {10, 23, 30};
+      a2 = new int[] {100, 230, 300};
+      Assert.assertEquals(rows5.size(), d1.length);
+      for (int i = 0; i < rows5.size(); i++) {
+        Assert.assertEquals(d1[i], rows5.get(i).getString(0));
+        Assert.assertEquals(d2[i], rows5.get(i).getInt(1));
+        Assert.assertEquals(a1[i], rows5.get(i).getInt(2));
+        Assert.assertEquals(a2[i], rows5.get(i).getInt(3));
+      }
     }
   }
 


### PR DESCRIPTION
This PR  pushes down the ```OR``` operator to use the Query Condition API. Many changes were needed in the source code to achieve this. 

The new implementation also supports complex expressions that combine both OR and AND applied to both dimensions and attributes. (e.g.```(a1 > 25 OR a1 < 20) AND d2 = 50```).

The tests have also been redesigned to test more complex cases. 

Finally a new boolean flag has been added:  ```tiledb_filtering```. This flag, when ```false```, can disable the use of Query Condition and leave all filtering to the Spark level. It is ```true``` by default.  