### PR TITLE
Dstara/add support for the float scaling filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ A dedicated jar `tiledb-spark-metrics-$version.jar` is built by default to
 allow a user to place this in the class path. Typically this jar can be copied
 to `$SPARK_HOME/jars/`.
 
-
 ## Options
 
 ### Read/Write options
@@ -100,9 +99,10 @@ to `$SPARK_HOME/jars/`.
 * `schema.tile_order` (optional): Specify the tile order. Filter list is a tuple of the form `(name, option)`, ex: `"(byteshuffle, -1), (gzip, 9)"`
 * `schema.coords_filter_list` (optional): Specify the coordinate filter list
 * `schema.offsets_filter_list` (optional): Specify the offsets filter list
+* `schema.<ATT_NAME>.filter_list` (optional): Specify the attribute filter list
 * `metadata_value.<KEY>` (optional): The metadata value for a given key
 * `metadata_type.<KEY>` (optional): The metadata datatype for a given key
-
+  <br /><br /> Note: Filters are passed as options as shown [here](https://github.com/TileDB-Inc/TileDB-Spark/blob/abcbce41950d105a609aeed5d2d498f64945f2bc/src/test/java/io/tiledb/spark/NullableAttributesTest.java#L519). Each filter needs to have at least one parameter. Use -1 if the filter in use does not take any parameters (e.g (byteshuffle, -1))
 ## Semantics
 
 ### Type Mapping

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation 'org.apache.spark:spark-sql_2.12:3.2.0'
     implementation 'org.apache.spark:spark-core_2.12:3.2.0'
 
-    implementation 'io.tiledb:tiledb-java:0.13.0'
+    implementation 'io.tiledb:tiledb-java:0.13.4'
 
     implementation 'commons-beanutils:commons-beanutils:1.9.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation 'org.apache.spark:spark-sql_2.12:3.2.0'
     implementation 'org.apache.spark:spark-core_2.12:3.2.0'
 
-    implementation 'io.tiledb:tiledb-java:0.13.4'
+    implementation 'io.tiledb:tiledb-java:0.13.6'
 
     implementation 'commons-beanutils:commons-beanutils:1.9.4'
 

--- a/src/main/java/io/tiledb/spark/TileDBBatchWrite.java
+++ b/src/main/java/io/tiledb/spark/TileDBBatchWrite.java
@@ -181,14 +181,14 @@ public class TileDBBatchWrite implements BatchWrite {
         arraySchema.setTileOrder(schemaTileOrder.get());
       }
       // schema filters
-      Optional<List<Pair<String, Integer>>> coordsFilters = options.getSchemaCoordsFilterList();
+      Optional<List<Pair<String, Object[]>>> coordsFilters = options.getSchemaCoordsFilterList();
       if (coordsFilters.isPresent()) {
         try (FilterList filterList =
             TileDBWriteSchema.createTileDBFilterList(ctx, coordsFilters.get())) {
           arraySchema.setCoodsFilterList(filterList);
         }
       }
-      Optional<List<Pair<String, Integer>>> offsetsFilters = options.getSchemaOffsetsFilterList();
+      Optional<List<Pair<String, Object[]>>> offsetsFilters = options.getSchemaOffsetsFilterList();
       if (coordsFilters.isPresent()) {
         try (FilterList filterList =
             TileDBWriteSchema.createTileDBFilterList(ctx, offsetsFilters.get())) {

--- a/src/test/java/io/tiledb/spark/FiltersTest.java
+++ b/src/test/java/io/tiledb/spark/FiltersTest.java
@@ -1,0 +1,109 @@
+package io.tiledb.spark;
+
+import io.tiledb.java.api.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FiltersTest extends SharedJavaSparkSession {
+  private static Context ctx;
+  private String[] filters;
+  private String sparseURI;
+
+  private String writeArrayURI;
+
+  @Before
+  public void setup() throws Exception {
+    ctx = new Context();
+    sparseURI = "sparse_array";
+    writeArrayURI = "temp";
+    filters =
+        new String[] {
+          "NONE",
+          "GZIP, -1",
+          "ZSTD, -1",
+          "LZ4, -1",
+          "RLE, -1",
+          "BZIP2, -1",
+          "DOUBLE_DELTA, -1",
+          "BIT_WIDTH_REDUCTION, -1",
+          "BITSHUFFLE, -1",
+          "BYTESHUFFLE, -1",
+          "POSITIVE_DELTA, -1",
+          "SCALE_FLOAT, 1.0, 1.0, 8"
+        };
+    deleteArrays();
+  }
+
+  @After
+  public void delete() throws Exception {
+    deleteArrays();
+    ctx.close();
+  }
+
+  private void deleteArrays() throws TileDBError {
+    if (Files.exists(Paths.get(sparseURI))) {
+      TileDBObject.remove(ctx, sparseURI);
+    }
+    if (Files.exists(Paths.get(writeArrayURI))) {
+      TileDBObject.remove(ctx, writeArrayURI);
+    }
+  }
+
+  @Test
+  public void filtersTest() {
+    for (String filter : filters) {
+      Dataset<Row> dfReadFirst = TestUtil.createSparseDataset(session());
+      // dfReadFirst.show();
+      dfReadFirst
+          .write()
+          .format("io.tiledb.spark")
+          .option("schema.dim.0.name", "d1")
+          .option("schema.dim.0.min", 1)
+          .option("schema.dim.0.max", 8)
+          .option("schema.dim.0.extent", 2)
+          .option("schema.attr.a1.filter_list", filter)
+          .option("schema.cell_order", "row-major")
+          .option("schema.tile_order", "row-major")
+          .option("schema.capacity", 3)
+          .mode("overwrite")
+          .save(writeArrayURI);
+
+      Dataset<Row> dfRead = session().read().format("io.tiledb.spark").load(writeArrayURI);
+      dfRead.createOrReplaceTempView("tmp");
+      List<Row> rows = session().sql("SELECT * FROM tmp").collectAsList();
+      Assert.assertEquals(5, rows.size());
+
+      Row row = rows.get(0);
+      Assert.assertEquals(1, row.get(0));
+      Assert.assertNull(row.get(1));
+      Assert.assertEquals("a", row.get(2));
+
+      row = rows.get(1);
+      Assert.assertEquals(2, row.get(0));
+      Assert.assertNull(row.get(1));
+      Assert.assertEquals("b", row.get(2));
+
+      row = rows.get(2);
+      Assert.assertEquals(3, row.get(0));
+      Assert.assertNull(row.get(1));
+      Assert.assertEquals("c", row.get(2));
+
+      row = rows.get(3);
+      Assert.assertEquals(4, row.get(0));
+      Assert.assertEquals(4.0f, row.get(1));
+      Assert.assertNull(row.get(2));
+
+      row = rows.get(4);
+      Assert.assertEquals(5, row.get(0));
+      Assert.assertEquals(5.0f, row.get(1));
+      Assert.assertNull(row.get(2));
+    }
+  }
+}

--- a/src/test/java/io/tiledb/spark/NullableAttributesTest.java
+++ b/src/test/java/io/tiledb/spark/NullableAttributesTest.java
@@ -408,57 +408,9 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
   ==============================================================
    */
 
-  /**
-   * Sparse dataset with fixed-size attributes.
-   *
-   * @param ss The spark session.
-   * @return The created dataframe.
-   */
-  public Dataset<Row> createSparseDataset(SparkSession ss) {
-    StructField[] structFields =
-        new StructField[] {
-          new StructField("d1", DataTypes.IntegerType, false, Metadata.empty()),
-          new StructField("a1", DataTypes.FloatType, true, Metadata.empty()),
-          new StructField("a2", DataTypes.StringType, true, Metadata.empty()),
-        };
-    List<Row> rows = new ArrayList<>();
-    rows.add(RowFactory.create(1, null, "a"));
-    rows.add(RowFactory.create(2, null, "b"));
-    rows.add(RowFactory.create(3, null, "c"));
-    rows.add(RowFactory.create(4, 4.0f, null));
-    rows.add(RowFactory.create(5, 5.0f, null));
-    StructType structType = new StructType(structFields);
-    Dataset<Row> df = ss.createDataFrame(rows, structType);
-    return df;
-  }
-
-  /**
-   * Sparse dataset with var-size attributes.
-   *
-   * @param ss The spark session.
-   * @return The created dataframe.
-   */
-  public Dataset<Row> createSparseDatasetVar(SparkSession ss) {
-    StructField[] structFields =
-        new StructField[] {
-          new StructField("d1", DataTypes.IntegerType, false, Metadata.empty()),
-          new StructField("a1", DataTypes.IntegerType, true, Metadata.empty()),
-          new StructField("a2", DataTypes.StringType, true, Metadata.empty()),
-        };
-    List<Row> rows = new ArrayList<>();
-    rows.add(RowFactory.create(1, null, "aaa"));
-    rows.add(RowFactory.create(2, null, "b"));
-    rows.add(RowFactory.create(3, null, "cccc"));
-    rows.add(RowFactory.create(4, 4, null));
-    rows.add(RowFactory.create(5, 5, null));
-    StructType structType = new StructType(structFields);
-    Dataset<Row> df = ss.createDataFrame(rows, structType);
-    return df;
-  }
-
   @Test
   public void sparseWriteTest() throws Exception {
-    Dataset<Row> dfReadFirst = createSparseDataset(session());
+    Dataset<Row> dfReadFirst = TestUtil.createSparseDataset(session());
     // dfReadFirst.show();
     dfReadFirst
         .write()
@@ -507,7 +459,7 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
 
   @Test
   public void sparseWriteVarAttTest() throws Exception {
-    Dataset<Row> dfReadFirst = createSparseDatasetVar(session());
+    Dataset<Row> dfReadFirst = TestUtil.createSparseDatasetVar(session());
     // dfReadFirst.show();
     dfReadFirst
         .write()

--- a/src/test/java/io/tiledb/spark/NullableAttributesTest.java
+++ b/src/test/java/io/tiledb/spark/NullableAttributesTest.java
@@ -418,15 +418,15 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
     StructField[] structFields =
         new StructField[] {
           new StructField("d1", DataTypes.IntegerType, false, Metadata.empty()),
-          new StructField("a1", DataTypes.IntegerType, true, Metadata.empty()),
+          new StructField("a1", DataTypes.FloatType, true, Metadata.empty()),
           new StructField("a2", DataTypes.StringType, true, Metadata.empty()),
         };
     List<Row> rows = new ArrayList<>();
     rows.add(RowFactory.create(1, null, "a"));
     rows.add(RowFactory.create(2, null, "b"));
     rows.add(RowFactory.create(3, null, "c"));
-    rows.add(RowFactory.create(4, 4, null));
-    rows.add(RowFactory.create(5, 5, null));
+    rows.add(RowFactory.create(4, 4.0f, null));
+    rows.add(RowFactory.create(5, 5.0f, null));
     StructType structType = new StructType(structFields);
     Dataset<Row> df = ss.createDataFrame(rows, structType);
     return df;
@@ -467,7 +467,7 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
         .option("schema.dim.0.min", 1)
         .option("schema.dim.0.max", 8)
         .option("schema.dim.0.extent", 2)
-        .option("schema.attr.a1.filter_list", "(byteshuffle, -1), (gzip, -10)")
+        .option("schema.attr.a1.filter_list", "(scale_float, 1.0, 1.0, 8)")
         .option("schema.cell_order", "row-major")
         .option("schema.tile_order", "row-major")
         .option("schema.capacity", 3)
@@ -496,12 +496,12 @@ public class NullableAttributesTest extends SharedJavaSparkSession {
 
     row = rows.get(3);
     Assert.assertEquals(4, row.get(0));
-    Assert.assertEquals(4, row.get(1));
+    Assert.assertEquals(4.0f, row.get(1));
     Assert.assertNull(row.get(2));
 
     row = rows.get(4);
     Assert.assertEquals(5, row.get(0));
-    Assert.assertEquals(5, row.get(1));
+    Assert.assertEquals(5.0f, row.get(1));
     Assert.assertNull(row.get(2));
   }
 

--- a/src/test/java/io/tiledb/spark/TestUtil.java
+++ b/src/test/java/io/tiledb/spark/TestUtil.java
@@ -1,0 +1,62 @@
+package io.tiledb.spark;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+public class TestUtil {
+  /**
+   * Sparse dataset with fixed-size attributes.
+   *
+   * @param ss The spark session.
+   * @return The created dataframe.
+   */
+  public static Dataset<Row> createSparseDataset(SparkSession ss) {
+    StructField[] structFields =
+        new StructField[] {
+          new StructField("d1", DataTypes.IntegerType, false, Metadata.empty()),
+          new StructField("a1", DataTypes.FloatType, true, Metadata.empty()),
+          new StructField("a2", DataTypes.StringType, true, Metadata.empty()),
+        };
+    List<Row> rows = new ArrayList<>();
+    rows.add(RowFactory.create(1, null, "a"));
+    rows.add(RowFactory.create(2, null, "b"));
+    rows.add(RowFactory.create(3, null, "c"));
+    rows.add(RowFactory.create(4, 4.0f, null));
+    rows.add(RowFactory.create(5, 5.0f, null));
+    StructType structType = new StructType(structFields);
+    Dataset<Row> df = ss.createDataFrame(rows, structType);
+    return df;
+  }
+
+  /**
+   * Sparse dataset with var-size attributes.
+   *
+   * @param ss The spark session.
+   * @return The created dataframe.
+   */
+  public static Dataset<Row> createSparseDatasetVar(SparkSession ss) {
+    StructField[] structFields =
+        new StructField[] {
+          new StructField("d1", DataTypes.IntegerType, false, Metadata.empty()),
+          new StructField("a1", DataTypes.IntegerType, true, Metadata.empty()),
+          new StructField("a2", DataTypes.StringType, true, Metadata.empty()),
+        };
+    List<Row> rows = new ArrayList<>();
+    rows.add(RowFactory.create(1, null, "aaa"));
+    rows.add(RowFactory.create(2, null, "b"));
+    rows.add(RowFactory.create(3, null, "cccc"));
+    rows.add(RowFactory.create(4, 4, null));
+    rows.add(RowFactory.create(5, 5, null));
+    StructType structType = new StructType(structFields);
+    Dataset<Row> df = ss.createDataFrame(rows, structType);
+    return df;
+  }
+}

--- a/src/test/java/io/tiledb/spark/TileDBDataSourceOptionsTest.java
+++ b/src/test/java/io/tiledb/spark/TileDBDataSourceOptionsTest.java
@@ -168,24 +168,24 @@ public class TileDBDataSourceOptionsTest {
   @Test
   public void testSingleFilter() throws Exception {
     String filters = "(gzip, 2)";
-    Optional<List<Pair<String, Integer>>> filterList =
+    Optional<List<Pair<String, Object[]>>> filterList =
         TileDBDataSourceOptions.tryParseFilterList(filters);
     Assert.assertTrue(filterList.isPresent());
     Assert.assertEquals(1, filterList.get().size());
     Assert.assertEquals("gzip", filterList.get().get(0).getFirst());
-    Assert.assertEquals(Integer.valueOf(2), filterList.get().get(0).getSecond());
+    Assert.assertEquals("2", filterList.get().get(0).getSecond()[0]);
   }
 
   @Test
   public void testFilterList() throws Exception {
     String filters = "(byteshuffle, -1), (gzip, 2)";
-    Optional<List<Pair<String, Integer>>> filterList =
+    Optional<List<Pair<String, Object[]>>> filterList =
         TileDBDataSourceOptions.tryParseFilterList(filters);
     Assert.assertTrue(filterList.isPresent());
     Assert.assertEquals(2, filterList.get().size());
     Assert.assertEquals("byteshuffle", filterList.get().get(0).getFirst());
-    Assert.assertEquals(Integer.valueOf(-1), filterList.get().get(0).getSecond());
+    Assert.assertEquals("-1", filterList.get().get(0).getSecond()[0]);
     Assert.assertEquals("gzip", filterList.get().get(1).getFirst());
-    Assert.assertEquals(Integer.valueOf(2), filterList.get().get(1).getSecond());
+    Assert.assertEquals("2", filterList.get().get(1).getSecond()[0]);
   }
 }


### PR DESCRIPTION
This PR adds support for the ```SCALE_FLOAT``` filter. It also adds support for filter options of various types (e.g. float, double, etc.)

In addition I added a new FiltersTest class to test the correct functionality of all TileDB filters.

Finally, some updates to the ```README``` file to clarify filters usage. 